### PR TITLE
Add nginx WebSocket upgrade headers to the deployment example

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -202,6 +202,13 @@ In production, place Pyxle behind a reverse proxy (Nginx, Caddy, etc.) for TLS t
 ### Nginx example
 
 ```nginx
+# Maps the Upgrade header so a WebSocket request sends "Connection: upgrade"
+# while an ordinary request sends "Connection: close".
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 443 ssl;
     server_name example.com;
@@ -215,6 +222,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Required if any page exposes a `websocket` handler / uses useWebSocket.
+        # Without these, nginx proxies the wss:// handshake as a plain GET and the
+        # connection silently never upgrades (the client just sees the page HTML).
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 3600s;   # keep long-lived WebSockets from idling out
     }
 
     # Cache static assets
@@ -226,6 +241,12 @@ server {
 }
 ```
 
+> **WebSocket apps:** the `proxy_http_version 1.1` + `Upgrade`/`Connection` lines
+> above are what let `wss://` connections through. A reverse proxy that omits them
+> serves the page fine but every WebSocket silently fails to connect. (Browsers do
+> the WebSocket handshake over HTTP/1.1 even when the listener also speaks HTTP/2 —
+> that's expected; the headers above handle it.)
+
 ### Caddy example
 
 ```
@@ -233,6 +254,9 @@ example.com {
     reverse_proxy localhost:8000
 }
 ```
+
+Caddy's `reverse_proxy` upgrades WebSocket connections automatically — no extra
+configuration is needed.
 
 ## CDN and edge caching
 

--- a/docs/guides/websockets.md
+++ b/docs/guides/websockets.md
@@ -249,6 +249,15 @@ Options: `onMessage(data, event)`, `protocols`, `reconnect` (default `true`),
 current origin with the matching scheme (`wss:` on `https:`); an absolute
 `ws://` / `wss://` URL passes through.
 
+## Behind a reverse proxy
+
+If you serve Pyxle behind nginx (or any proxy), the proxy must be told to pass
+the WebSocket **upgrade** through — otherwise the `wss://` handshake is proxied
+as an ordinary request, the page still loads, and every WebSocket silently fails
+to connect. See [Deployment → Reverse proxy setup](deployment.md#reverse-proxy-setup)
+for the `proxy_set_header Upgrade` / `Connection` lines. (Caddy upgrades
+WebSockets automatically.)
+
 ## See also
 
 - [API routes](api-routes.md) — `pages/api/**` modules can export a `websocket`


### PR DESCRIPTION
While deploying the Pulse demo, `wss://` connections silently failed behind nginx: the proxy returned the page HTML (200) instead of `101 Switching Protocols`. The app upgrades fine (direct upstream returns 101) — the gap was the reverse proxy.

The framework's own [Deployment → Reverse proxy setup](docs/guides/deployment.md) nginx example proxied `location /` **without** `proxy_http_version 1.1` or the `Upgrade`/`Connection` headers, so any user who ships a WebSocket page (a documented 0.5.0 feature) and copies the example hits the same silent failure.

- Add the `map $http_upgrade $connection_upgrade` block + `proxy_http_version 1.1` / `Upgrade` / `Connection` / `proxy_read_timeout 3600s` to the nginx example, with a symptom callout.
- Note that Caddy upgrades WebSockets automatically.
- Add a "Behind a reverse proxy" section to the WebSockets guide.

Docs-only; no code change (WebSockets themselves work).