### PR TITLE
Sync current-version badge to 0.5.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,18 @@
 
 Pyxle is a Python-first full-stack web framework that brings the Next.js developer experience to the Python ecosystem. Write server logic in Python, UI in React, and ship them together in `.pyxl` files.
 
-**Current version:** 0.4.5 (beta)
+**Current version:** 0.5.0 (beta)
+
+## What's new in 0.5.0
+
+The **depth release** — going deep on the production path.
+
+- **Server-side caching, SSG & ISR.** A `@server` loader can cache its rendered HTML (`{"data", "revalidate": N}`), `pyxle build --static` pre-renders loader-less pages, and stale pages revalidate in the background. See [Caching](guides/caching.md).
+- **Streaming SSR.** `<Suspense>` pages flush the shell first, then stream boundaries as they resolve — and it survives production gzip. See [Streaming SSR](guides/streaming.md).
+- **Realtime WebSockets.** Page `websocket` handlers, a `useWebSocket` hook, and `pyxle.realtime` pub/sub, with a **cross-worker Redis broker** for multi-process serving. See [WebSockets](guides/websockets.md).
+- **Pydantic-validated actions.** Annotate an `@action` body with a Pydantic model for automatic parse/validate/`422`, plus `pyxle openapi`. See [Server Actions](core-concepts/server-actions.md).
+- **Observability.** Request IDs, timing, Prometheus metrics, structured logging, a dev dashboard, and opt-in OpenTelemetry. See [Observability](guides/observability.md).
+- **Background tasks, image optimization, and multi-worker serving** (`pyxle serve --workers N`). See the [Changelog](changelog.md) for the full list.
 
 ## What's new in 0.4.0
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ Those frameworks let you build the UI in pure Python; Pyxle has you write real R
 
 ### Is Pyxle production-ready?
 
-Pyxle is in **beta** (version 0.4.0). The core features are implemented and tested (1,370+ tests, with a 95% coverage gate enforced in CI), but the API may change before 1.0. Use it for new projects and experiments, but be prepared for breaking changes.
+Pyxle is in **beta** (version 0.5.0). The core features are implemented and tested (2,100+ tests, with a 95% coverage gate enforced in CI), but the API may change before 1.0. Use it for new projects and experiments, but be prepared for breaking changes.
 
 ### What Python version do I need?
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -2,7 +2,7 @@
 
 Pyxle is a Python-first full-stack web framework that brings the Next.js developer experience to the Python ecosystem. You write your server logic in Python, your UI in React, and ship them together in a single `.pyxl` file — no separate API layer, no second service, no glue code between them.
 
-**Current version:** 0.4.0 (beta)
+**Current version:** 0.5.0 (beta)
 
 ## One file, two languages
 
@@ -43,7 +43,7 @@ The loader's return value *is* the component's `data` prop. There's no `fetch`, 
 
 ## What's new
 
-Pyxle 0.4.0 adds **edge caching**, **hardened production errors**, and **faster static serving**. See the full [Changelog](../changelog.md) for release notes.
+Pyxle 0.5.0 — the **depth release** — adds server-side **caching, SSG & ISR**, **streaming SSR**, **realtime WebSockets** (with a cross-worker Redis broker), **Pydantic-validated actions**, **observability**, **background tasks**, image optimization, and **multi-worker serving**. See the full [Changelog](../changelog.md) for release notes.
 
 ---
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -2,7 +2,7 @@
 
 Pyxle plugins are reusable pieces of functionality — database layers, auth systems, storage adapters — that a host app composes via `pyxle.config.json` rather than hand-wiring in its entry point. The design is deliberately Django-inspired: declare what you want, and the framework handles discovery, startup order, and lifecycle.
 
-> **Status (0.4.0).** This guide covers the Phase A plugin surface: lifecycle hooks, named services, and middleware contribution. Page contribution (plugins shipping their own `.pyxl` pages that get merged into the host's route tree — the "pyxle-auth ships a default `/sign-in` page" use case) is a Phase B follow-up. Everything documented here is stable; the additions in Phase B will be strictly additive.
+> **Status (0.5.0).** This guide covers the Phase A plugin surface: lifecycle hooks, named services, and middleware contribution. Page contribution (plugins shipping their own `.pyxl` pages that get merged into the host's route tree — the "pyxle-auth ships a default `/sign-in` page" use case) is a Phase B follow-up. Everything documented here is stable; the additions in Phase B will be strictly additive.
 
 ## TL;DR
 


### PR DESCRIPTION
The docs Introduction page showed **Current version: 0.4.0 (beta)** (and the README had drifted to 0.4.5) after the 0.5.0 release. Bumps the badge to 0.5.0 across introduction/faq/plugins/README, refreshes the intro + README "What's new" to the 0.5.0 highlights, and updates the FAQ test count.

Paired with a pyxle.dev change that makes `build-docs.mjs` **auto-sync** the `Current version` badge from `pyproject.toml`, so it can never silently drift again (verified: a bogus badge in the .md still renders the real version).