### PR TITLE
Sharper pyxle check: semantic analysis, duplicate-export detection, accurate JSX lines

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include breaking changes — those are called out explicitly here. To upgrade, run `pip install --upgrade pyxle-framework`.
 
+## 0.6.1 — 2026-07-01
+
+A sharper `pyxle check` — the edit → check → fix loop now catches classes of mistake it used to wave through.
+
+- **`pyxle check` gained a semantic layer.** Beyond Python syntax, it now runs pyflakes over the Python section and reports **undefined names** — e.g. a handler that `raise`s a symbol it never imported — plus unused imports and redefinitions. Compiler-injected runtime names are recognized, so the idiomatic decorators and error classes never read as undefined.
+- **Duplicate `export default` is now caught.** `@babel/parser` accepts two default exports even though the build (esbuild) rejects them — so a build-breaking mistake used to pass `check` and only fail later, pointing into a generated path. It's now flagged at check time, at the real source line.
+- **JSX error lines are now accurate.** A JSX syntax error was always reported at the first line of the JSX section; it now points at the actual line. Babel's misleading "Unterminated regular expression" (its lexer's guess for an unclosed `{ }`) also carries a plain-language hint about the real cause.
+- **`LoaderError` and `invalidate_routes` are now auto-injected**, matching `ActionError` / `ValidationActionError`. `raise LoaderError(...)` in a loader just works with no import — closing an inconsistency where the action-side equivalent already did. A name you import or define yourself still takes precedence. See [Runtime API](reference/runtime-api.md).
+- **`pyxle install --break-system-packages`.** For externally-managed (PEP 668) Python environments without a virtualenv, `pyxle install` now offers the flag and points to it in the no-venv warning. See [CLI → pyxle install](reference/cli.md#pyxle-install).
+
 ## 0.6.0 — 2026-07-01
 
 - **AI accessibility — serve your app as markdown, plus `llms.txt`.** A new opt-in `llms` config block makes every Pyxle app legible to AI assistants and coding agents. Enable it (`"llms": true`) and the framework serves a clean **markdown** rendition of each page at its URL with `.md` appended (`/docs/routing.md`), returns markdown from the same URL to requests that send `Accept: text/markdown` (browsers are unaffected), serves an **`/llms.txt`** index, and advertises it with `Link`/`X-Llms-Txt` discovery headers. A page's markdown is resolved from your project — a co-located `<page>.md` file, a `to_markdown` handler in the page's server module, or a `to_markdown` in the nearest ancestor `llms.py` (which scopes to a whole route subtree; `pages/llms.py` is app-wide) — with an opt-in `autoConvert` HTML→markdown fallback and a redirect-to-the-page fallback when nothing resolves. `/llms.txt` comes from a static `public/llms.txt`, a `llms_txt` hook in `pages/llms.py`, or a generated index, and a `wrap_markdown` hook in `pages/llms.py` can frame every `.md` response with a header/footer (e.g. agent navigation hints). Off by default; adds nothing to the page hot path. See the [AI accessibility guide](guides/llms.md) and [Configuration → AI accessibility](reference/configuration.md#ai-accessibility).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,6 +48,7 @@ pyxle install [directory] [options]
 | `directory` | `.` | Project directory |
 | `--python` / `--no-python` | `true` | Install Python deps via `pip` |
 | `--node` / `--no-node` | `true` | Install Node deps via `npm` |
+| `--break-system-packages` | `false` | Pass `--break-system-packages` to `pip`, for externally-managed (PEP 668) environments without a virtualenv. Use with care. |
 
 **Examples:**
 
@@ -55,7 +56,10 @@ pyxle install [directory] [options]
 pyxle install
 pyxle install --no-python    # Node only
 pyxle install ./my-app
+pyxle install --break-system-packages   # PEP 668 system Python, no venv
 ```
+
+Outside a virtualenv, `pyxle install` warns about PEP 668 ("externally-managed-environment") and recommends creating a venv first; pass `--break-system-packages` to install anyway.
 
 ## `pyxle dev`
 
@@ -160,7 +164,11 @@ sizing guidance.
 
 ## `pyxle check`
 
-Validate `.pyxl` syntax, configuration, and dependencies.
+Validate `.pyxl` files, configuration, and dependencies without starting the server. Each `.pyxl` file is checked at three levels:
+
+- **Python syntax** (via `ast`) and Pyxle structural rules (loader/action shape, `HEAD`, …).
+- **Python semantics** (via pyflakes): undefined names — e.g. a symbol you `raise` but never imported — unused imports, redefinitions. Compiler-injected runtime names (`server`, `action`, `LoaderError`, `ActionError`, …) are recognized, so the idiomatic patterns never read as undefined.
+- **JSX syntax** (via Babel): unclosed tags/expressions, mismatched braces, TypeScript in a client block, and **duplicate `export default`** (which Babel accepts but the build rejects).
 
 ```bash
 pyxle check [directory] [options]

--- a/docs/reference/runtime-api.md
+++ b/docs/reference/runtime-api.md
@@ -1,8 +1,11 @@
 # Runtime API Reference
 
-The `pyxle.runtime` module provides decorators and error classes used in `.pyxl` files. The compiler **auto-injects** a small set: the `@server` decorator, and — in any file that declares at least one `@action` — the `@action` decorator plus `ActionError` and `ValidationActionError`. You do not import those.
+The `pyxle.runtime` module provides decorators and error classes used in `.pyxl` files. The compiler **auto-injects** the ones you use in the idiomatic patterns, so you rarely import from `pyxle.runtime` at all:
 
-Other `pyxle.runtime` symbols, including **`LoaderError`**, are **not** auto-injected — import them explicitly: `from pyxle.runtime import LoaderError`.
+- a file with a `@server` loader gets `server` and **`LoaderError`**;
+- a file with an `@action` gets `action`, **`ActionError`**, **`ValidationActionError`**, and **`invalidate_routes`**.
+
+So `raise LoaderError(...)` / `raise ActionError(...)` work without an import. You can still import any of them explicitly (a name you define or import yourself always takes precedence over the auto-injection). `pyxle check` reports any name you genuinely left undefined.
 
 ## `@server`
 
@@ -89,11 +92,9 @@ Requires the `[pydantic]` extra (`pip install "pyxle-framework[pydantic]"`). On 
 
 ## `LoaderError`
 
-Exception class for structured loader errors. Triggers the nearest `error.pyxl` boundary.
+Exception class for structured loader errors. Triggers the nearest `error.pyxl` boundary. Auto-injected in any file with a `@server` loader — no import needed.
 
 ```python
-from pyxle.runtime import LoaderError
-
 @server
 async def load_page(request):
     raise LoaderError("Not found", status_code=404, data={"id": 42})
@@ -396,10 +397,8 @@ The callable receives the loader's return value. Must return a string or list of
 
 ## Explicit imports
 
-While the compiler auto-injects `@server` and `@action`, you can also import explicitly:
+The compiler auto-injects the names you use in the idiomatic patterns (see the top of this page), so you usually import nothing. You can still import any of them explicitly — useful for type checking and IDE support, and a name you import or define yourself always takes precedence over the auto-injection:
 
 ```python
-from pyxle.runtime import server, action, LoaderError, ActionError, ValidationActionError
+from pyxle.runtime import server, action, LoaderError, ActionError, ValidationActionError, invalidate_routes
 ```
-
-This is useful for type checking and IDE support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyxle-framework"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python-first full-stack framework with an intelligent CLI."
 readme = "README.md"
 authors = [
@@ -39,7 +39,12 @@ dependencies = [
   # (no-JS submissions sending ``application/x-www-form-urlencoded`` /
   # ``multipart/form-data``). Without it Starlette raises ``AssertionError``
   # the first time form parsing is attempted.
-  "python-multipart>=0.0.9,<1.0"
+  "python-multipart>=0.0.9,<1.0",
+  # pyflakes powers the semantic layer of ``pyxle check`` (undefined names,
+  # unused imports, redefinitions) beyond the parser's syntax check. Tiny and
+  # pure-Python with zero transitive dependencies; imported lazily so it only
+  # loads for ``pyxle check``, never on the compile/serve hot path.
+  "pyflakes>=3.1,<4.0"
 ]
 
 [project.urls]

--- a/pyxle/cli/__init__.py
+++ b/pyxle/cli/__init__.py
@@ -195,21 +195,26 @@ def _install_dependencies(
     logger: ConsoleLogger,
     install_python: bool = True,
     install_node: bool = True,
+    break_system_packages: bool = False,
 ) -> None:
     if not install_python and not install_node:
         logger.warning("Skipping dependency installation (both installers disabled).")
         return
 
     if install_python:
-        if not _in_virtualenv():
+        if not _in_virtualenv() and not break_system_packages:
             logger.warning(
                 "No virtual environment detected. Installing into the system "
-                "Python can fail on modern Linux (PEP 668 'externally-managed-"
+                "Python can fail on modern distros (PEP 668 'externally-managed-"
                 "environment'). Recommended: create one first — "
                 "`python -m venv .venv && source .venv/bin/activate` "
-                "(Windows: `.venv\\Scripts\\activate`) — then run `pyxle install`."
+                "(Windows: `.venv\\Scripts\\activate`) — then run `pyxle install`. "
+                "To install into this environment anyway, re-run with "
+                "`--break-system-packages`."
             )
         python_cmd = [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
+        if break_system_packages:
+            python_cmd.append("--break-system-packages")
         _run_subprocess(
             python_cmd,
             cwd=project_root,
@@ -248,6 +253,14 @@ def install(
         help="Install Node dependencies via npm.",
         show_default=True,
     ),
+    break_system_packages: bool = typer.Option(
+        False,
+        "--break-system-packages",
+        help=(
+            "Pass --break-system-packages to pip, for externally-managed "
+            "(PEP 668) environments without a virtualenv. Use with care."
+        ),
+    ),
 ) -> None:
     """Install project dependencies inside the specified directory."""
 
@@ -258,6 +271,7 @@ def install(
         logger=logger,
         install_python=python_deps,
         install_node=node_deps,
+        break_system_packages=break_system_packages,
     )
 
 
@@ -912,7 +926,10 @@ def check(
             # diagnostics for every file that follows.
             try:
                 result = parser.parse(
-                    pyxl_file, tolerant=True, validate_jsx=True
+                    pyxl_file,
+                    tolerant=True,
+                    validate_jsx=True,
+                    validate_semantics=True,
                 )
             except Exception as exc:  # noqa: BLE001 — defensive CLI boundary
                 diagnostics.append(

--- a/pyxle/compiler/parser.py
+++ b/pyxle/compiler/parser.py
@@ -1159,10 +1159,74 @@ def _validate_jsx_syntax(
     if not result.error:
         return
 
-    line = jsx_line_numbers[0] if jsx_line_numbers else None
+    # Map Babel's 1-indexed line (within the extracted JSX section) back to the
+    # real .pyxl line via ``jsx_line_numbers`` — mirroring the TS-violation
+    # mapping above. Fall back to the section's first line when Babel reports no
+    # line or one out of range, so a diagnostic never points nowhere.
+    line: int | None = jsx_line_numbers[0] if jsx_line_numbers else None
+    if (
+        result.error_line is not None
+        and 0 <= result.error_line - 1 < len(jsx_line_numbers)
+    ):
+        line = jsx_line_numbers[result.error_line - 1]
     collector.emit(
         f"JSX syntax error: {result.error}", line, section="jsx"
     )
+
+
+#: Runtime names the compiler auto-injects into the server module (see
+#: ``compiler/writers.py``). pyflakes must treat them as defined so ``@server`` /
+#: ``@action`` / ``raise ActionError(...)`` / ``raise LoaderError(...)`` never
+#: read as undefined even when the user hasn't written an import.
+_INJECTED_RUNTIME_NAMES = frozenset(
+    {
+        "server",
+        "action",
+        "ActionError",
+        "ValidationActionError",
+        "LoaderError",
+        "invalidate_routes",
+    }
+)
+
+
+def _validate_python_semantics(
+    tree: ast.Module | None,
+    python_line_numbers: Sequence[int],
+    *,
+    collector: _DiagnosticCollector,
+) -> None:
+    """Run pyflakes over the Python section for semantic issues.
+
+    Opt-in via ``validate_semantics=True``. This is the layer beyond
+    ``ast.parse``'s syntax check: it catches undefined names (e.g. a handler
+    that ``raise``s a symbol it never imported), unused imports, redefinitions,
+    and the rest of pyflakes' analysis. Compiler-injected runtime names are
+    whitelisted so the idiomatic decorators and error classes never read as
+    undefined.
+
+    pyflakes is imported lazily so the fast compile/build path never pays for
+    it; if it isn't installed the check is silently skipped.
+    """
+    if tree is None:
+        return
+    try:
+        from pyflakes.checker import Checker  # lazy: only for `pyxle check`
+    except ImportError:  # pragma: no cover - pyflakes is a declared dependency
+        return
+
+    try:
+        checker = Checker(tree, filename="<pyxl>", builtins=_INJECTED_RUNTIME_NAMES)
+    except Exception:  # noqa: BLE001 — never let a linter crash the parse
+        return
+
+    for message in checker.messages:
+        try:
+            text = message.message % message.message_args
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            text = str(message.message)
+        line = _map_lineno(getattr(message, "lineno", None), python_line_numbers)
+        collector.emit(text, line, section="python")
 
 
 # ---------------------------------------------------------------------------
@@ -1179,6 +1243,7 @@ class PyxParser:
         *,
         tolerant: bool = False,
         validate_jsx: bool = False,
+        validate_semantics: bool = False,
     ) -> PyxParseResult:
         """Parse a ``.pyxl`` file from disk into a :class:`PyxParseResult`.
 
@@ -1201,7 +1266,12 @@ class PyxParser:
             (~200ms per call).
         """
         text = source_path.read_text(encoding="utf-8-sig")
-        return self.parse_text(text, tolerant=tolerant, validate_jsx=validate_jsx)
+        return self.parse_text(
+            text,
+            tolerant=tolerant,
+            validate_jsx=validate_jsx,
+            validate_semantics=validate_semantics,
+        )
 
     def parse_text(
         self,
@@ -1209,6 +1279,7 @@ class PyxParser:
         *,
         tolerant: bool = False,
         validate_jsx: bool = False,
+        validate_semantics: bool = False,
     ) -> PyxParseResult:
         """Parse a ``.pyxl`` source string into a :class:`PyxParseResult`."""
         lines = _normalize_newlines(text)
@@ -1314,6 +1385,13 @@ class PyxParser:
         if validate_jsx and jsx_code.strip() and not has_python_errors:
             _validate_jsx_syntax(
                 jsx_code, jsx_line_numbers, collector=collector
+            )
+        # Semantic (name-level) analysis of the Python section — the layer past
+        # ``ast.parse``. Gated on a clean Python parse so pyflakes analyses real
+        # code, not content a mis-split absorbed into the wrong section.
+        if validate_semantics and python_code.strip() and not has_python_errors:
+            _validate_python_semantics(
+                tree, python_line_numbers, collector=collector
             )
 
         diagnostics = tuple(

--- a/pyxle/compiler/writers.py
+++ b/pyxle/compiler/writers.py
@@ -18,6 +18,8 @@ _ACTION_IMPORT = "from pyxle.runtime import action"
 _SERVER_ACTION_IMPORT = "from pyxle.runtime import server, action"
 _ACTION_ERROR_IMPORT = "from pyxle.runtime import ActionError"
 _VALIDATION_ACTION_ERROR_IMPORT = "from pyxle.runtime import ValidationActionError"
+_LOADER_ERROR_IMPORT = "from pyxle.runtime import LoaderError"
+_INVALIDATE_ROUTES_IMPORT = "from pyxle.runtime import invalidate_routes"
 
 
 @dataclass
@@ -68,6 +70,17 @@ class ArtifactWriter:
         if has_actions and python_code.strip():
             python_code = ensure_action_error_import(python_code)
             python_code = ensure_validation_action_error_import(python_code)
+            # ``invalidate_routes`` is the action-side helper that evicts a
+            # route's cached navigation payload after a mutation — inject it
+            # alongside ``ActionError`` for the same no-surprise reason.
+            python_code = ensure_invalidate_routes_import(python_code)
+        # A ``@server`` loader raises ``LoaderError`` to trigger the nearest
+        # ``error.pyxl`` boundary, exactly as an ``@action`` raises
+        # ``ActionError`` — so auto-import it for parity. Without this, the first
+        # ``raise LoaderError(...)`` fails with a bewildering NameError even
+        # though the equivalent action pattern works out of the box.
+        if has_loader and python_code.strip():
+            python_code = ensure_loader_error_import(python_code)
         jsx_code = (
             parse_result.jsx_code
             if parse_result.jsx_code.strip()
@@ -307,6 +320,30 @@ def ensure_validation_action_error_import(source: str) -> str:
     """
     return _ensure_runtime_name_import(
         source, "ValidationActionError", _VALIDATION_ACTION_ERROR_IMPORT
+    )
+
+
+def ensure_loader_error_import(source: str) -> str:
+    """Ensure ``from pyxle.runtime import LoaderError`` is present.
+
+    Called whenever the source declares a ``@server`` loader, so the idiomatic
+    ``raise LoaderError(...)`` pattern — which renders the nearest ``error.pyxl``
+    boundary — works without a manual import. Parity with
+    :func:`ensure_action_error_import`. A user who already owns the name is
+    detected and this is a no-op.
+    """
+    return _ensure_runtime_name_import(source, "LoaderError", _LOADER_ERROR_IMPORT)
+
+
+def ensure_invalidate_routes_import(source: str) -> str:
+    """Ensure ``from pyxle.runtime import invalidate_routes`` is present.
+
+    Auto-imported for pages with at least one ``@action`` — the helper that
+    evicts a route's cached navigation payload after a mutation. A user-defined
+    name still takes precedence.
+    """
+    return _ensure_runtime_name_import(
+        source, "invalidate_routes", _INVALIDATE_ROUTES_IMPORT
     )
 
 

--- a/pyxle/templates/scaffold/AGENTS.md
+++ b/pyxle/templates/scaffold/AGENTS.md
@@ -17,9 +17,10 @@ frameworks — most mistakes come from not understanding the one-file Python+Rea
    route to write — the `@action` *is* the endpoint.
 4. `@server`/`@action` return a **plain dict.** On the client, an action's result arrives
    **wrapped** as `{ ok: true, ...yourDict }` (or `{ ok: false, error }`). Always check `res.ok`.
-5. To raise a handled error you **must import it**: `from pyxle.runtime import ActionError,
-   LoaderError`. (The decorators are auto-injected; these exception classes are not — forgetting
-   this is the #1 `NameError`.)
+5. Raise a handled error with `raise LoaderError(...)` (in a loader) or `raise ActionError(...)`
+   (in an action) — **no import needed.** Like the decorators, these runtime classes
+   (`LoaderError`, `ActionError`, `ValidationActionError`, `invalidate_routes`) are auto-injected.
+   `pyxle check` reports any name you genuinely left undefined, and any duplicate `export default`.
 6. Secrets stay server-side. An env var is exposed to the browser **only** if it is prefixed
    `PYXLE_PUBLIC_`. Never return secrets/tokens from a loader or action (they're serialized to
    the client).
@@ -32,7 +33,7 @@ frameworks — most mistakes come from not understanding the one-file Python+Rea
 # pages/index.pyxl
 
 # ── Python (server) ─────────────────────────────────────────────
-# @server / @action need no import. ActionError/LoaderError DO (see below).
+# @server / @action / LoaderError / ActionError all work without imports (auto-injected).
 
 @server
 async def load(request):
@@ -94,16 +95,14 @@ async def load(request):              # any function name works; @server marks i
   JSON-safe values.
 - `request` is a Starlette `Request`: `request.path_params`, `request.query_params`,
   `request.headers`, `request.cookies`, `request.url`.
-- To fail with a status code: `from pyxle.runtime import LoaderError` then
-  `raise LoaderError("Not found", status_code=404)`.
+- To fail with a status code: `raise LoaderError("Not found", status_code=404)` (auto-injected,
+  no import needed).
 - A page **without** a `@server` loader is fine — it just renders statically (the component
   takes no `data`).
 
 ## Mutations — `@action`
 
 ```python
-from pyxle.runtime import ActionError    # required to raise it
-
 @action
 async def create_post(request):
     body = await request.json()

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -93,6 +93,7 @@ def test_install_invokes_dependency_helper(monkeypatch) -> None:
             logger,
             install_python=True,
             install_node=True,
+            break_system_packages=False,
         ):
             called["root"] = project_root.resolve()
             called["python"] = install_python
@@ -474,6 +475,7 @@ def test_init_optionally_installs_dependencies(monkeypatch) -> None:
             logger,
             install_python=True,
             install_node=True,
+            break_system_packages=False,
         ):
             called["root"] = project_root.resolve()
 
@@ -1499,7 +1501,9 @@ def test_check_command_survives_per_file_parser_crash(monkeypatch) -> None:
     real_parse = parser_module.PyxParser.parse
     crash_target = "crashy.pyxl"
 
-    def fake_parse(self, source_path, *, tolerant=False, validate_jsx=False):
+    def fake_parse(
+        self, source_path, *, tolerant=False, validate_jsx=False, validate_semantics=False
+    ):
         if source_path.name == crash_target:
             raise RuntimeError("simulated parser crash")
         return real_parse(
@@ -1507,6 +1511,7 @@ def test_check_command_survives_per_file_parser_crash(monkeypatch) -> None:
             source_path,
             tolerant=tolerant,
             validate_jsx=validate_jsx,
+            validate_semantics=validate_semantics,
         )
 
     monkeypatch.setattr(parser_module.PyxParser, "parse", fake_parse)
@@ -1564,7 +1569,9 @@ def test_check_command_handles_diagnostic_without_line() -> None:
     # and verify the CLI formats it without crashing on the missing line.
     from pyxle.compiler.parser import PyxDiagnostic, PyxParseResult
 
-    def fake_parse(self, path, *, tolerant=False, validate_jsx=False):
+    def fake_parse(
+        self, path, *, tolerant=False, validate_jsx=False, validate_semantics=False
+    ):
         return PyxParseResult(
             python_code="",
             jsx_code="",
@@ -2822,3 +2829,25 @@ def test_dist_has_websocket_pages(tmp_path: Path) -> None:
     # Malformed manifest → False (never raises).
     manifest.write_text("not json", encoding="utf-8")
     assert cli._dist_has_websocket_pages(dist) is False
+
+
+def test_install_dependencies_break_system_packages(monkeypatch, tmp_path) -> None:
+    """--break-system-packages threads through to the pip command for PEP-668."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(cli.subprocess, "run", lambda command, *, cwd, check: calls.append(command))
+    monkeypatch.setattr(cli, "_in_virtualenv", lambda: False)
+    cli._install_dependencies(
+        tmp_path,
+        logger=cli.ConsoleLogger(),
+        install_node=False,
+        break_system_packages=True,
+    )
+    assert "--break-system-packages" in calls[0]
+
+
+def test_install_no_break_flag_by_default(monkeypatch, tmp_path) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(cli.subprocess, "run", lambda command, *, cwd, check: calls.append(command))
+    monkeypatch.setattr(cli, "_in_virtualenv", lambda: True)
+    cli._install_dependencies(tmp_path, logger=cli.ConsoleLogger(), install_node=False)
+    assert "--break-system-packages" not in calls[0]

--- a/tests/compiler/test_action_writers.py
+++ b/tests/compiler/test_action_writers.py
@@ -7,6 +7,8 @@ from textwrap import dedent
 from pyxle.compiler.writers import (
     ensure_action_error_import,
     ensure_action_import,
+    ensure_invalidate_routes_import,
+    ensure_loader_error_import,
     ensure_server_action_import,
     ensure_validation_action_error_import,
 )
@@ -265,3 +267,55 @@ class TestEnsureValidationActionErrorImport:
         result = ensure_validation_action_error_import(source)
         assert "from pyxle.runtime import ValidationActionError" in result
         assert result.count("from pyxle.runtime import ActionError") == 1
+
+
+class TestEnsureLoaderErrorImport:
+    """A ``@server`` loader can ``raise LoaderError(...)`` to hit the nearest
+    ``error.pyxl`` boundary without a manual import — parity with ActionError."""
+
+    def test_adds_import_when_missing(self) -> None:
+        source = "async def load(request):\n    raise LoaderError('x')\n"
+        result = ensure_loader_error_import(source)
+        assert "from pyxle.runtime import LoaderError" in result
+
+    def test_no_duplicate_when_already_present(self) -> None:
+        source = (
+            "from pyxle.runtime import LoaderError\n"
+            "async def load(request):\n    pass\n"
+        )
+        result = ensure_loader_error_import(source)
+        assert result.count("from pyxle.runtime import LoaderError") == 1
+
+    def test_empty_source_returned_unchanged(self) -> None:
+        assert ensure_loader_error_import("") == ""
+
+    def test_respects_existing_combined_import(self) -> None:
+        source = (
+            "from pyxle.runtime import server, LoaderError\n"
+            "async def load(request):\n    pass\n"
+        )
+        assert ensure_loader_error_import(source) == source
+
+    def test_does_not_shadow_local_class(self) -> None:
+        source = "class LoaderError(Exception):\n    pass\n"
+        assert ensure_loader_error_import(source) == source
+
+
+class TestEnsureInvalidateRoutesImport:
+    """Pages with an ``@action`` get ``invalidate_routes`` auto-imported."""
+
+    def test_adds_import_when_missing(self) -> None:
+        source = "async def save(request):\n    pass\n"
+        result = ensure_invalidate_routes_import(source)
+        assert "from pyxle.runtime import invalidate_routes" in result
+
+    def test_no_duplicate_when_already_present(self) -> None:
+        source = (
+            "from pyxle.runtime import invalidate_routes\n"
+            "async def save(request):\n    pass\n"
+        )
+        result = ensure_invalidate_routes_import(source)
+        assert result.count("from pyxle.runtime import invalidate_routes") == 1
+
+    def test_empty_source_returned_unchanged(self) -> None:
+        assert ensure_invalidate_routes_import("") == ""

--- a/tests/compiler/test_compile.py
+++ b/tests/compiler/test_compile.py
@@ -155,7 +155,12 @@ def test_compile_injects_import_after_docstring(tmp_path: Path) -> None:
     server_lines = result.server_output.read_text(encoding="utf-8").splitlines()
     non_empty = [line for line in server_lines if line.strip()]
     assert non_empty[0] == '"""Demo docstring."""'
-    assert non_empty[1] == "from pyxle.runtime import server"
+    # A loader page auto-injects both `server` and `LoaderError` — always AFTER
+    # the docstring (injecting before it would demote the docstring to a plain
+    # string expression). Order between the two isn't contractual.
+    injected = {non_empty[1], non_empty[2]}
+    assert "from pyxle.runtime import server" in injected
+    assert "from pyxle.runtime import LoaderError" in injected
 
 
 def test_compile_preserves_existing_server_import(tmp_path: Path) -> None:

--- a/tests/compiler/test_parser_diagnostics.py
+++ b/tests/compiler/test_parser_diagnostics.py
@@ -1088,3 +1088,134 @@ class TestTypeScriptGuard:
             assert f"Line {ts_line}" in str(exc)
         else:
             pytest.skip("Babel extractor unavailable; the guard degraded gracefully")
+
+
+class TestSemanticValidation:
+    """``validate_semantics=True`` runs pyflakes over the Python section."""
+
+    def _sem(self, text: str):
+        return PyxParser().parse_text(
+            dedent(text).strip("\n"), tolerant=True, validate_semantics=True
+        )
+
+    def test_undefined_name_flagged(self):
+        result = self._sem(
+            """
+            @server
+            async def load(request):
+                return {"x": compute_total(request)}
+
+            import React from 'react'
+
+            export default function P({ data }) {
+                return <div>{data.x}</div>
+            }
+            """
+        )
+        assert any(
+            d.section == "python" and "undefined name 'compute_total'" in d.message
+            for d in result.diagnostics
+        )
+
+    def test_injected_runtime_names_not_flagged(self):
+        # @server/@action + LoaderError/ActionError/invalidate_routes used with
+        # no imports must NOT read as undefined — the compiler injects them.
+        result = self._sem(
+            """
+            @server
+            async def load(request):
+                if request is None:
+                    raise LoaderError("x")
+                return {}
+
+            @action
+            async def save(request):
+                if not request:
+                    raise ActionError("y")
+                return invalidate_routes({"ok": True}, "/posts")
+
+            import React from 'react'
+
+            export default function P() {
+                return <div/>
+            }
+            """
+        )
+        assert not any(d.section == "python" for d in result.diagnostics)
+
+    def test_off_by_default(self):
+        result = PyxParser().parse_text(
+            dedent(
+                """
+                @server
+                async def load(request):
+                    return {"x": mystery()}
+
+                import React from 'react'
+
+                export default function P({ data }) {
+                    return <div>{data.x}</div>
+                }
+                """
+            ).strip("\n"),
+            tolerant=True,
+        )
+        assert not any("undefined name" in d.message for d in result.diagnostics)
+
+    def test_line_maps_to_pyxl_source(self):
+        result = self._sem(
+            """
+            @server
+            async def load(request):
+                value = 1
+                return {"x": nope(value)}
+
+            import React from 'react'
+
+            export default function P({ data }) {
+                return <div>{data.x}</div>
+            }
+            """
+        )
+        diags = [d for d in result.diagnostics if "undefined name 'nope'" in d.message]
+        assert diags and diags[0].line == 4
+
+
+class TestJsxErrorLineMapping:
+    """A Babel error must map to the real .pyxl line, not the JSX block start."""
+
+    def _run(self, monkeypatch, error_line):
+        from pyxle.compiler import jsx_parser
+        from pyxle.compiler.jsx_parser import JSXParseResult
+
+        monkeypatch.setattr(
+            jsx_parser,
+            "parse_jsx_components",
+            lambda jsx_code, *, target_components=None: JSXParseResult(
+                components=(), error="boom", error_line=error_line
+            ),
+        )
+        return PyxParser().parse_text(
+            dedent(
+                """
+                import React from 'react'
+
+                export default function P() {
+                    return <div>ok</div>
+                }
+                """
+            ).strip("\n"),
+            tolerant=True,
+            validate_jsx=True,
+        )
+
+    def test_error_maps_to_reported_line(self, monkeypatch):
+        result = self._run(monkeypatch, error_line=3)
+        jsx = [d for d in result.diagnostics if d.section == "jsx"]
+        # snippet line 3 -> file line 3 (the export line), NOT the block start (1).
+        assert jsx and jsx[0].line == 3
+
+    def test_missing_line_falls_back_to_block_start(self, monkeypatch):
+        result = self._run(monkeypatch, error_line=None)
+        jsx = [d for d in result.diagnostics if d.section == "jsx"]
+        assert jsx and jsx[0].line == 1


### PR DESCRIPTION
Hardens the `pyxle check` flagship command, which caught only syntax before.

- **Semantic layer (pyflakes).** Flags undefined names — e.g. a handler that `raise`s a symbol it never imported — plus unused imports and redefinitions. Opt-in `validate_semantics` on the parser (mirrors `validate_jsx`); compiler-injected runtime names are whitelisted so the idiomatic decorators/error classes never read as undefined. pyflakes added as a lazily-imported dependency; verified no false positives on the pyxle.dev site.
- **Duplicate `export default`** is now flagged at check time. `@babel/parser` accepts two default exports though esbuild rejects them at build — so a build-breaking mistake used to pass `check`. (Detection ships in the JSX extractor — pyxle-langkit.)
- **Accurate JSX error lines.** `_validate_jsx_syntax` used to report the JSX block's first line for every error; it now maps Babel's real line. Babel's misleading "Unterminated regular expression" also gets a plain-language hint.
- **Auto-inject `LoaderError` + `invalidate_routes`** (parity with `ActionError`/`ValidationActionError`) — `raise LoaderError(...)` works with no import.
- **`pyxle install --break-system-packages`** for externally-managed (PEP 668) environments.

Docs: AGENTS.md, runtime-api, CLI reference, changelog **0.6.1**. Full suite green (coverage ≥ 95%).