### PR TITLE
Simulate GitHub Issues for Pyxle Framework Vulnerabilities

### DIFF
--- a/.github/issues/issue_csrf_tokens_match_typeerror.md
+++ b/.github/issues/issue_csrf_tokens_match_typeerror.md
@@ -1,0 +1,38 @@
+# Bug Report: Potential TypeError crash in `_tokens_match` (CSRF Middleware)
+
+## Description
+In `pyxle/devserver/csrf.py`, the `_tokens_match` function uses `hmac.compare_digest(cookie_token, submitted_token)` directly. While it asserts that `cookie_token` and `submitted_token` are non-empty strings with `if not cookie_token or not submitted_token: return False`, it lacks strict type checking. `python-multipart` parses file fields as `UploadFile` objects. If a malicious client sends a multipart request with a file uploaded in the `_csrf_token` field (or another data type that passes truthiness checks but fails string/bytes assertions), `hmac.compare_digest` will raise a `TypeError` (e.g., `TypeError: a bytes-like object is required, not 'UploadFile'` or similar).
+
+Since this logic runs as middleware before reaching exception handlers designed to catch application-level errors, this unhandled exception crashes the ASGI connection handling this specific request, returning a `500 Internal Server Error` (handled gracefully by Starlette base app but still an unhandled exception trace in logs) instead of a `403 Forbidden` that would happen on a normal invalid token. This acts as an unexpected Denial of Service vector for parsing malicious payloads.
+
+## Affected Code
+```python
+# pyxle/devserver/csrf.py
+def _tokens_match(cookie_token: str, submitted_token: str, secret: str) -> bool:
+    if not cookie_token or not submitted_token:
+        return False
+
+    # Double-submit: submitted value must match cookie value.
+    if not hmac.compare_digest(cookie_token, submitted_token):
+        return False
+```
+
+## Recommended Fix
+Ensure both variables are strings before comparison, similar to protections seen elsewhere.
+
+```python
+<<<<<<< SEARCH
+    if not cookie_token or not submitted_token:
+        return False
+
+    # Double-submit: submitted value must match cookie value.
+=======
+    if not cookie_token or not submitted_token:
+        return False
+
+    if not isinstance(cookie_token, str) or not isinstance(submitted_token, str):
+        return False
+
+    # Double-submit: submitted value must match cookie value.
+>>>>>>> REPLACE
+```

--- a/.github/issues/issue_validate_port.md
+++ b/.github/issues/issue_validate_port.md
@@ -1,0 +1,28 @@
+# Bug Report: `_validate_port` accepts booleans as valid integer ports
+
+## Description
+In `pyxle/config.py`, the `_validate_port` function checks if the port value is an integer using `isinstance(value, int)`. However, in Python, `bool` is a subclass of `int`. As a result, if a user configures a boolean value like `True` or `False` for a port (e.g., `starlette.port`), the check passes because `True` evaluates to `1` and `False` evaluates to `0`.
+
+While `0` is caught by `value <= 0`, `True` bypasses the check entirely and evaluates to `1`. This means a port configuration like `{"port": True}` will silently start the server on port `1`, which requires root privileges and is definitely unintended behavior, bypassing the expected configuration error.
+
+## Affected Code
+```python
+# pyxle/config.py
+def _validate_port(value: Any, key: str) -> int:
+    if not isinstance(value, int):
+        raise ConfigError(f"Invalid value for '{key}': expected integer port value.")
+    if value <= 0 or value > 65535:
+        raise ConfigError(f"Port for '{key}' must be between 1 and 65535 (got {value}).")
+    return value
+```
+
+## Recommended Fix
+Add a check to explicitly reject boolean values. This is already done elsewhere in `config.py` for other integer fields.
+
+```python
+<<<<<<< SEARCH
+    if not isinstance(value, int):
+=======
+    if not isinstance(value, int) or isinstance(value, bool):
+>>>>>>> REPLACE
+```


### PR DESCRIPTION
Created `.github/issues/` directory and generated markdown files to simulate GitHub issue creation for two identified vulnerabilities:
1. `_validate_port` boolean parsing vulnerability in `pyxle/config.py`
2. `_tokens_match` TypeError crash vulnerability in `pyxle/devserver/csrf.py`

This ensures that the issues are documented for review without directly modifying the framework codebase. Checked that no prior open issues existed and no regressions were introduced.

---
*PR created automatically by Jules for task [4648978832877537263](https://jules.google.com/task/4648978832877537263) started by @shivamsn97*