### PR TITLE
Reject boolean port values in config validation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include breaking changes — those are called out explicitly here. To upgrade, run `pip install --upgrade pyxle-framework`.
 
+## Unreleased
+
+- **Config: a boolean port is now rejected instead of silently binding port 1.** Because `bool` is a subclass of `int` in Python, `{"starlette": {"port": true}}` slipped past the port validator and bound port `1` (or `0`). `_validate_port` now rejects booleans with a clear `ConfigError`, matching every other integer setting in the config.
+
 ## 0.7.1 — 2026-07-10
 
 - **Security: require Starlette ≥ 1.3.1.** Pyxle was pinned to `starlette>=0.37,<0.38`, holding it on 0.37.2 — which has known advisories including a `Host`-header URL-reconstruction **auth bypass** (PYSEC-2026-161), unbounded form-parsing **DoS** (PYSEC-2026-249, PYSEC-2026-1943), and a Windows `StaticFiles` UNC **SSRF/credential leak** (CVE-2026-48818). The dependency is now `starlette>=1.3.1,<2.0`, which fixes all of them. Pyxle's own API surface is unchanged; upgrade with `pip install --upgrade pyxle-framework`. (Apps that import Starlette internals directly should review the Starlette 1.0 release notes.) A new `pip-audit` CI job guards against dependency regressions going forward.

--- a/pyxle/config.py
+++ b/pyxle/config.py
@@ -696,7 +696,9 @@ def _parse_network_block(value: Any, key: str, source: Path) -> tuple[str, int]:
 
 
 def _validate_port(value: Any, key: str) -> int:
-    if not isinstance(value, int):
+    # ``bool`` is a subclass of ``int`` — reject it explicitly so ``true``/``false``
+    # in JSON can't silently bind port 1/0 (matches the other integer validators).
+    if not isinstance(value, int) or isinstance(value, bool):
         raise ConfigError(f"Invalid value for '{key}': expected integer port value.")
     if value <= 0 or value > 65535:
         raise ConfigError(f"Port for '{key}' must be between 1 and 65535 (got {value}).")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,25 @@ def test_load_config_rejects_invalid_navigation_ttl(tmp_path: Path, bad: object)
     assert "defaultPrefetchTtl" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"starlette": {"port": True}},
+        {"starlette": {"port": False}},
+        {"vite": {"port": True}},
+    ],
+)
+def test_load_config_rejects_bool_port(tmp_path: Path, block: dict) -> None:
+    # ``bool`` is an ``int`` subclass; a JSON ``true`` must not silently bind
+    # port 1 — the validator rejects it like any other non-integer.
+    write_config(tmp_path, block)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(tmp_path)
+
+    assert "port" in str(excinfo.value).lower()
+
+
 def test_load_config_rejects_non_object_navigation_block(tmp_path: Path) -> None:
     write_config(tmp_path, {"navigation": "nope"})
 


### PR DESCRIPTION
`bool` is a subclass of `int` in Python, so `_validate_port` accepted `True`/`False` — a config like `{"starlette": {"port": true}}` slipped past `isinstance(value, int)` and silently bound port **1** (or `0`), instead of raising a clear error. `_validate_port` is the only integer validator in `config.py` that missed this guard (ttl, rate-limit requests/window, CORS max-age, etc. all reject `bool`).

Now it rejects booleans with a `ConfigError`, consistent with the rest of the config validation. Adds parametrized tests for `starlette.port` / `vite.port` booleans.

Found via #33.