### PR TITLE
Align README benchmark claims with the re-measured 0.7.1 numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ JavaScript; in return you get the whole React ecosystem with none of the two-rep
 
 **[Full framework comparison &rarr;](https://pyxle.dev/docs/guides/comparison)** &nbsp; Honest about when to reach for Reflex, Django, NiceGUI, Streamlit, or Next.js + FastAPI *instead*.
 
-**Fast, and benchmarked in the open.** Pyxle is **faster than Next.js at dynamic SSR** &mdash; 2.3&ndash;4.3&times; on equivalent pages &mdash; and **faster than FastAPI** on raw API throughput, giving you both in one framework.
+**Fast, and benchmarked in the open.** Pyxle renders dynamic SSR **~2&times; faster than Next.js** per core &mdash; the same DOM in 2&ndash;3&times; fewer bytes &mdash; and runs **on par with FastAPI** on API throughput, pulling ahead once a request does real database work.
 &rarr; **[See the benchmarks](https://pyxle.dev/benchmarks)** &mdash; full data with framework versions, honest caveats, and a reproducible harness.
 
 **Built for AI coding agents.** Shipping a feature on a Next.js + FastAPI stack means holding two


### PR DESCRIPTION
Corrects the benchmark line in the README to match the re-measured 0.7.1 numbers (see the paired pyxle.dev benchmarks PR).

- "faster than Next.js at dynamic SSR — 2.3–4.3×" → "**~2× faster than Next.js** per core — the same DOM in 2–3× fewer bytes"
- "**faster than FastAPI** on raw API throughput" → "**on par with FastAPI** on API throughput, pulling ahead once a request does real database work"

The old line overstated both results. Holding alongside the benchmarks-page refresh — nothing here needs to merge before that framing is approved.