### PR TITLE
Release 0.7.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include breaking changes — those are called out explicitly here. To upgrade, run `pip install --upgrade pyxle-framework`.
 
-## Unreleased
+## 0.7.2 — 2026-07-11
 
 - **Fix: `pyxle init` scaffolds an installable `requirements.txt` again.** The template pinned `starlette>=0.37,<0.38` — the exact range 0.7.1's security bump moved off — so a fresh project's `requirements.txt` was unsatisfiable against the `pyxle-framework>=0.7.1` line beside it (which requires `starlette>=1.3.1`), and `pip install -r requirements.txt` failed to resolve. The scaffold now pins `starlette>=1.3.1,<2.0`, matching the framework.
 - **Config: a boolean port is now rejected instead of silently binding port 1.** Because `bool` is a subclass of `int` in Python, `{"starlette": {"port": true}}` slipped past the port validator and bound port `1` (or `0`). `_validate_port` now rejects booleans with a clear `ConfigError`, matching every other integer setting in the config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyxle-framework"
-version = "0.7.1"
+version = "0.7.2"
 description = "Python-first full-stack framework with an intelligent CLI."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Patch release. Two fixes land:

- **Fresh installs work again** — the scaffolded `requirements.txt` pinned `starlette>=0.37,<0.38`, which conflicts with the framework's own `starlette>=1.3.1` requirement, so `pip install -r requirements.txt` in a brand-new project failed to resolve. The scaffold now pins `starlette>=1.3.1,<2.0`.
- **`pyxle serve --port` rejects a boolean** instead of silently binding port 1 (because `bool` is an `int` subclass in Python).

No API changes. Upgrade with `pip install --upgrade pyxle-framework`.