### PR TITLE
Cover interpreter selection in the debugging guide

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include breaking changes — those are called out explicitly. To upgrade, run `pip install --upgrade pyxle-framework`.
 
+## Unreleased
+
+- **Docs: the debugging guide covers picking the interpreter from a `.pyxl` file.** Both VS Code debug configurations run the dev server under the interpreter VS Code has selected, so the guide now points at the status-bar item (and the **Pyxle: Select Python Interpreter** command) that Pyxle Language Tools shows while a `.pyxl` file is open, and notes that the pre-launch check tests what the interpreter can run rather than the version its package metadata reports — an editable install with stale dist-info is no longer refused. [Debugging](guides/debugging.md).
+
 ## 0.8.0
 
 - **Pyxle Studio — a dashboard built into `pyxle dev`.** Served at `/__pyxle/studio`: every route with its loader, actions, cache posture, and boundaries; an interactive tester (loaders run in-process, actions go through their real endpoint — CSRF, validation, and auth hooks included); a live request feed; latency metrics; the effective config (secrets redacted); and in-browser `pyxle check`. Dev-only by construction, with a `Host`-header allowlist. [Pyxle Studio](guides/studio.md).

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -30,7 +30,9 @@ Two more requirements, both one-time:
 - **pyxle-framework 0.8.0 or newer** in the environment VS Code has selected. The
   debugger relies on line mapping added in 0.8.0 and launches the dev server as
   `python -m pyxle`, which earlier versions don't provide. Upgrade with
-  `pip install --upgrade pyxle-framework`.
+  `pip install --upgrade pyxle-framework`. While a `.pyxl` file is open, a
+  status-bar item shows which interpreter that is — click it (or run **Pyxle:
+  Select Python Interpreter**) to change it.
 - **The Python extension** (`ms-python.python`) for Python-side breakpoints. The
   debugger prompts you if it's missing, and still debugs the React side without it.
 
@@ -357,9 +359,13 @@ before launching and offers a **Select Interpreter** button; you can also run
 **Python: Select Interpreter** from the command palette and pick the environment
 your terminal's `pyxle` command uses (`which pyxle` / `where pyxle` shows it).
 
-**"No module named pyxle.\_\_main\_\_", or the debugger says to upgrade.** The
-selected interpreter has pyxle, but a version older than 0.8.0. Run
-`pip install --upgrade pyxle-framework` in that environment.
+**"No module named pyxle.\_\_main\_\_", or the debugger says the interpreter is
+too old.** The selected interpreter has pyxle, but a version older than 0.8.0.
+Either switch to the environment that has 0.8.0+ (**Select Interpreter** in the
+message, or the status-bar item while a `.pyxl` file is open) or run
+`pip install --upgrade pyxle-framework` in that environment. The check asks what
+the interpreter can actually *do*, not what its package metadata says, so an
+editable install whose recorded version is stale still launches normally.
 
 ---
 


### PR DESCRIPTION
## The issue

The debugging guide told readers that the debugger "checks it has pyxle before launching and guides you if not", and that a too-old interpreter means "run `pip install --upgrade pyxle-framework`". Both were incomplete in a way that misled people who hit the error with a working pyxle installed:

- The launch runs under **VS Code's selected interpreter**, and the usual cause of the error is that the right pyxle lives in a *different* environment. Upgrading the selected one is then the wrong fix — switching to the right one is.
- Nothing told the reader how to *see* or change that interpreter from a `.pyxl` file. The Python extension only shows its interpreter indicator for `.py` files, so the environment driving the launch was effectively invisible.
- The guide implied the check was version-based. It is capability-based, which matters for editable/dev installs whose recorded version lags the code on disk.

## The change

Docs only — no framework code.

- **Requirements**: note that both debug configurations use the selected interpreter, and point at the status-bar item (and the **Pyxle: Select Python Interpreter** command) that Pyxle Language Tools shows while a `.pyxl` file is open.
- **Troubleshooting**: the "too old" entry now offers switching environments as the first remedy alongside upgrading, and states that the check tests what the interpreter can run rather than the version its package metadata reports — so an editable install with stale dist-info is not refused.

The editor-side behaviour these lines describe is in pyxle-dev/pyxle-langkit#13. The changelog entry is under **Unreleased** so the published docs don't describe an editor release that isn't out yet.

## Checklist

- [x] `pytest` passes and coverage stays ≥ 95% (no code changed — docs only)
- [x] `ruff check pyxle/ tests/` is clean (no code changed)
- [x] New behavior has tests in the matching `tests/` directory (n/a — documentation change)
- [x] Touched the parser or SSR? Added regression tests and verified `pyxle init` + `pyxle dev` still work end-to-end (n/a — neither touched)
- [x] One focused change; commit messages follow Conventional Commits (`scope`: `compiler`, `ssr`, `cli`, …)
