### PR TITLE
fix(check): refuse an @action whose body parameter can never be filled

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -560,7 +560,7 @@ migration tool per app. See [pyxle-db → Migrations](../plugins/pyxle-db.md#mig
 
 Before deploying:
 
-- [ ] `pyxle check` passes with no errors (it exits `0` on warnings alone — an unused import will not block you; an unresolved reference **in the Python half** will). It does not resolve identifiers in the JSX half, so it is not a substitute for opening the page — do that too.
+- [ ] `pyxle check` passes with no errors (it exits `0` on warnings alone — an unused import will not block you; an unresolved reference **in the Python half**, or an `@action` asking for a body parameter it never annotated, will). It does not resolve identifiers in the JSX half, so it is not a substitute for opening the page — do that too.
 - [ ] `pyxle build` completes successfully (it exits non-zero if it cannot run Vite — never ship a `dist/` from a build that failed)
 - [ ] Node.js `>= 20.19` **and npm** are on the build machine's `PATH`
 - [ ] Node.js is `>= 20.19` on the server's `PATH`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -281,11 +281,12 @@ sizing guidance.
 
 ## `pyxle check`
 
-Validate `.pyxl` files, configuration, and dependencies without starting the server. Each `.pyxl` file is checked at three levels:
+Validate `.pyxl` files, configuration, and dependencies without starting the server. Each `.pyxl` file is checked at four levels:
 
 - **Python syntax** (via `ast`) and Pyxle structural rules (loader/action shape, `HEAD`, …).
 - **Python semantics** (via pyflakes): undefined names — e.g. a symbol you `raise` but never imported — unused imports, redefinitions. Compiler-injected runtime names (`server`, `action`, `LoaderError`, `ActionError`, …) are recognized, so the idiomatic patterns never read as undefined.
 - **JSX syntax** (via Babel): unclosed tags/expressions, mismatched braces, TypeScript in a client block, and **duplicate `export default`** (which Babel accepts but the build rejects).
+- **`@action` signatures**: an action that asks for a request body it never described — `async def bump(request, payload)` with no annotation on `payload` — is reported here rather than failing the first time someone triggers it. This is read off the parsed source, so `check` still never imports your module. An *annotated* body parameter is not flagged: whether Pydantic is installed is a property of the environment you deploy into, and `pyxle openapi` and the dev server answer that one.
 
 As of 0.7.0 the JSX level works out of the box — `pyxle-langkit`, which provides the Babel-based checker, ships with the framework. On earlier versions it required the `[langkit]` extra (`pip install 'pyxle-framework[langkit]'`); without it, the JSX check reported itself unavailable.
 
@@ -312,7 +313,7 @@ Findings are split by whether the code will actually break when it runs.
 
 | Severity | What it covers | Exit code |
 |----------|----------------|-----------|
-| **error** | Syntax errors, Pyxle structural rules, JSX syntax, and semantics that fail at runtime: unresolved references (`undefined name 'x'`), unbound locals, malformed `%`/`.format()` strings, `raise NotImplemented` | `1` |
+| **error** | Syntax errors, Pyxle structural rules, JSX syntax, an `@action` body parameter with no annotation, and semantics that fail at runtime: unresolved references (`undefined name 'x'`), unbound locals, malformed `%`/`.format()` strings, `raise NotImplemented` | `1` |
 | **warning** | Code that runs correctly but wants tidying: unused imports, unused locals and annotations, redefinitions, duplicate dict keys, f-strings with no placeholders, `is` against a literal | `0` |
 
 A semantic rule Pyxle does not recognise — one added by a future pyflakes — is reported as a warning, so upgrading a dependency can never turn into a surprise deploy blocker. This is what lets [the deployment checklist](../guides/deployment.md) gate a release on `pyxle check`: a leftover `import json` will not stop a deploy, an unresolved reference will.

--- a/pyxle/compiler/parser.py
+++ b/pyxle/compiler/parser.py
@@ -1585,6 +1585,87 @@ def _validate_python_semantics(
         )
 
 
+def _decorator_names(node: ast.AST) -> set[str]:
+    """Every decorator's trailing name — ``@action``, ``@action()``, ``@pyxle.action``."""
+    names: set[str] = set()
+    for decorator in getattr(node, "decorator_list", ()):
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.add(target.attr)
+    return names
+
+
+def _validate_action_signatures(
+    tree: ast.Module | None,
+    python_line_numbers: Sequence[int],
+    *,
+    collector: _DiagnosticCollector,
+) -> None:
+    """Flag an ``@action`` whose body parameter can never be filled.
+
+    ``async def act(request, payload)`` asks Pyxle to supply ``payload`` from
+    the request body while saying nothing about its shape, so the call fails
+    the first time anyone triggers it. ``pyxle openapi`` already refuses this
+    file; ``pyxle check`` — the command the deploy guide names as the gate —
+    used to pass it, which is worse than having no gate at all.
+
+    This reads the shape off the AST rather than importing the user's module,
+    so ``check`` stays static: no import-time side effects, no import errors as
+    a new failure class, no slower gate. It therefore sees only what is written
+    literally in the file, which is the shape the mistake actually takes. The
+    parameter rule and the message are :func:`resolve_body_model`'s, imported
+    from ``pyxle.runtime`` so the gate and the dispatcher cannot drift.
+    """
+    if tree is None:
+        return
+    from pyxle.runtime import UnannotatedActionBodyError
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if "action" not in _decorator_names(node):
+            continue
+
+        args = node.args
+        # Mirrors ``resolve_body_model``: the body is the first parameter other
+        # than ``request`` that the dispatcher could pass by name. Positional-only
+        # and ``*args``/``**kwargs`` are excluded there, so they are excluded here.
+        positional = list(args.args)
+        # A default makes the parameter optional, so it can never be the thing
+        # that breaks the call. ``args.defaults`` aligns to the tail of the
+        # positional list; ``kw_defaults`` aligns 1:1 with ``kwonlyargs``, where
+        # ``None`` means "no default".
+        optional = set(map(id, positional[len(positional) - len(args.defaults):])) if args.defaults else set()
+        optional |= {
+            id(arg)
+            for arg, default in zip(args.kwonlyargs, args.kw_defaults)
+            if default is not None
+        }
+        candidates = [
+            arg
+            for arg in positional + args.kwonlyargs
+            if arg.arg not in ("request", "self", "cls")
+        ]
+        if not candidates:
+            continue
+        body_arg = candidates[0]
+        required = id(body_arg) not in optional
+        if body_arg.annotation is not None or not required:
+            # Annotated is the dispatcher's problem (it may still need Pydantic
+            # installed, which is an environment fact this static gate cannot
+            # know). Optional simply keeps its default.
+            continue
+
+        collector.emit(
+            str(UnannotatedActionBodyError(param=body_arg.arg, action=node.name)),
+            _map_lineno(getattr(body_arg, "lineno", None), python_line_numbers),
+            section="python",
+            severity="error",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public parser
 # ---------------------------------------------------------------------------
@@ -1784,6 +1865,9 @@ class PyxParser:
         # code, not content a mis-split absorbed into the wrong section.
         if validate_semantics and python_code.strip() and not has_python_errors:
             _validate_python_semantics(
+                tree, python_line_numbers, collector=collector
+            )
+            _validate_action_signatures(
                 tree, python_line_numbers, collector=collector
             )
 

--- a/pyxle/devserver/starlette_app.py
+++ b/pyxle/devserver/starlette_app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import inspect
 import logging
@@ -2153,7 +2154,12 @@ def create_starlette_app(
             set_active_cache(page_cache)
             # Warm the cache from any build-time pre-rendered pages
             # (`pyxle build --static`) so their first request is a hit.
-            if prerender_dir is not None and prerender_dir.exists():
+            # ``Path.exists`` is a blocking stat, and this runs on the event
+            # loop during startup — ASYNC240, and CLAUDE.md §8. Once per
+            # process, but the rule is right and the fix is a thread hop.
+            if prerender_dir is not None and await asyncio.to_thread(
+                prerender_dir.exists
+            ):
                 static_paths = [route.path for route in select_static_pages(routes.pages)]
                 warmed = await warm_page_cache(page_cache, static_paths, prerender_dir)
                 if warmed:

--- a/pyxle/devserver/validation.py
+++ b/pyxle/devserver/validation.py
@@ -25,103 +25,21 @@ from dataclasses import dataclass
 from typing import Any, Callable
 from weakref import WeakKeyDictionary
 
-from pyxle.runtime import ValidationActionError
+# Re-exported: these moved to ``pyxle.runtime`` so ``pyxle check`` can reach the
+# same message without importing the devserver (and Starlette with it). Imported
+# here by name so every existing ``from pyxle.devserver.validation import ...``
+# keeps working and catches the identical class object.
+from pyxle.runtime import (
+    ActionBodyError,
+    PydanticNotInstalledError,
+    UnannotatedActionBodyError,
+    ValidationActionError,
+)
 
 try:  # PEP 604 ``X | None`` unions (Python 3.10+)
     from types import UnionType as _UnionType
 except ImportError:  # pragma: no cover - 3.9 and earlier
     _UnionType = None  # type: ignore[assignment]
-
-
-class ActionBodyError(RuntimeError):
-    """Pyxle cannot work out how to supply an action's body parameter.
-
-    Two shapes, one base so a caller cannot catch one and miss the other: the
-    parameter is annotated with a model but Pydantic is missing
-    (:class:`PydanticNotInstalledError`), or it carries no annotation at all,
-    so there is nothing to build a model from
-    (:class:`UnannotatedActionBodyError`). Every caller only surfaces
-    ``str(exc)``; the base exists to keep their ``except`` clauses honest, not
-    to carry behaviour.
-    """
-
-    def __init__(
-        self, message: str, *, action: str | None = None, source: str | None = None
-    ) -> None:
-        super().__init__(message)
-        self.action = action
-        self.source = source
-
-    def with_identity(self, *, action: str, source: str | None) -> "ActionBodyError":
-        """Return the same failure, naming the action and the file to edit.
-
-        The dispatcher raises these bare — reached while handling a request for
-        one specific action, "this action" is unambiguous. Schema generation
-        walks every action in the project, so it re-raises through this to say
-        which file.
-        """
-        raise NotImplementedError  # pragma: no cover - subclasses implement
-
-
-class PydanticNotInstalledError(ActionBodyError):
-    """An action needs Pydantic to validate its body, but it isn't installed.
-
-    Raised only when the body parameter **is** annotated: an unannotated one
-    does not need Pydantic to begin with, and saying otherwise sends the reader
-    to install a dependency that will not fix their problem — see
-    :class:`UnannotatedActionBodyError`.
-    """
-
-    def __init__(self, *, action: str | None = None, source: str | None = None) -> None:
-        if action is None:
-            subject = "This action validates"
-        else:
-            where = f" in {source}" if source else ""
-            subject = f"Action '{action}'{where} validates"
-        super().__init__(
-            f"{subject} its request body with a Pydantic model, but "
-            "Pydantic is not installed. Install it with: "
-            "pip install 'pyxle-framework[pydantic]'.",
-            action=action,
-            source=source,
-        )
-
-    def with_identity(self, *, action: str, source: str | None) -> "PydanticNotInstalledError":
-        return PydanticNotInstalledError(action=action, source=source)
-
-
-class UnannotatedActionBodyError(ActionBodyError):
-    """An action requires a parameter it never described, so nothing can fill it.
-
-    ``async def act(request, payload)`` asks Pyxle to supply ``payload`` from
-    the request body while saying nothing about its shape. Installing Pydantic
-    does not help — with Pydantic present the same call fails with
-    ``TypeError: act() missing 1 required positional argument`` — so the message
-    names the two things that do.
-    """
-
-    def __init__(
-        self, *, param: str, action: str | None = None, source: str | None = None
-    ) -> None:
-        if action is None:
-            subject = "This action"
-        else:
-            where = f" in {source}" if source else ""
-            subject = f"Action '{action}'{where}"
-        super().__init__(
-            f"{subject} requires a parameter '{param}' that Pyxle would have to "
-            f"supply from the request body, but '{param}' has no type "
-            "annotation, so there is nothing to build a request model from. "
-            "Either annotate it with a Pydantic model (and install Pydantic "
-            "with: pip install 'pyxle-framework[pydantic]'), or take only "
-            "'request' and read the body yourself with: await request.json().",
-            action=action,
-            source=source,
-        )
-        self.param = param
-
-    def with_identity(self, *, action: str, source: str | None) -> "UnannotatedActionBodyError":
-        return UnannotatedActionBodyError(param=self.param, action=action, source=source)
 
 
 @dataclass(frozen=True, slots=True)

--- a/pyxle/runtime.py
+++ b/pyxle/runtime.py
@@ -223,6 +223,108 @@ def invalidate_routes(response: Any, *urls: str) -> Any:
     return response
 
 
+
+# ---------------------------------------------------------------------------
+# The ``@action`` body-parameter contract
+#
+# These live beside ``action`` itself rather than in the devserver because the
+# rule they describe is a property of the decorator's signature, and two
+# consumers now need it: the dispatcher, which resolves the model from a live
+# function object, and ``pyxle check``, which reads the same shape off the AST
+# without importing user code. One writer of the message, two readers.
+# ---------------------------------------------------------------------------
+
+
+class ActionBodyError(RuntimeError):
+    """Pyxle cannot work out how to supply an action's body parameter.
+
+    Two shapes, one base so a caller cannot catch one and miss the other: the
+    parameter is annotated with a model but Pydantic is missing
+    (:class:`PydanticNotInstalledError`), or it carries no annotation at all,
+    so there is nothing to build a model from
+    (:class:`UnannotatedActionBodyError`). Every caller only surfaces
+    ``str(exc)``; the base exists to keep their ``except`` clauses honest, not
+    to carry behaviour.
+    """
+
+    def __init__(
+        self, message: str, *, action: str | None = None, source: str | None = None
+    ) -> None:
+        super().__init__(message)
+        self.action = action
+        self.source = source
+
+    def with_identity(self, *, action: str, source: str | None) -> "ActionBodyError":
+        """Return the same failure, naming the action and the file to edit.
+
+        The dispatcher raises these bare — reached while handling a request for
+        one specific action, "this action" is unambiguous. Schema generation
+        walks every action in the project, so it re-raises through this to say
+        which file.
+        """
+        raise NotImplementedError  # pragma: no cover - subclasses implement
+
+
+class PydanticNotInstalledError(ActionBodyError):
+    """An action needs Pydantic to validate its body, but it isn't installed.
+
+    Raised only when the body parameter **is** annotated: an unannotated one
+    does not need Pydantic to begin with, and saying otherwise sends the reader
+    to install a dependency that will not fix their problem — see
+    :class:`UnannotatedActionBodyError`.
+    """
+
+    def __init__(self, *, action: str | None = None, source: str | None = None) -> None:
+        if action is None:
+            subject = "This action validates"
+        else:
+            where = f" in {source}" if source else ""
+            subject = f"Action '{action}'{where} validates"
+        super().__init__(
+            f"{subject} its request body with a Pydantic model, but "
+            "Pydantic is not installed. Install it with: "
+            "pip install 'pyxle-framework[pydantic]'.",
+            action=action,
+            source=source,
+        )
+
+    def with_identity(self, *, action: str, source: str | None) -> "PydanticNotInstalledError":
+        return PydanticNotInstalledError(action=action, source=source)
+
+
+class UnannotatedActionBodyError(ActionBodyError):
+    """An action requires a parameter it never described, so nothing can fill it.
+
+    ``async def act(request, payload)`` asks Pyxle to supply ``payload`` from
+    the request body while saying nothing about its shape. Installing Pydantic
+    does not help — with Pydantic present the same call fails with
+    ``TypeError: act() missing 1 required positional argument`` — so the message
+    names the two things that do.
+    """
+
+    def __init__(
+        self, *, param: str, action: str | None = None, source: str | None = None
+    ) -> None:
+        if action is None:
+            subject = "This action"
+        else:
+            where = f" in {source}" if source else ""
+            subject = f"Action '{action}'{where}"
+        super().__init__(
+            f"{subject} requires a parameter '{param}' that Pyxle would have to "
+            f"supply from the request body, but '{param}' has no type "
+            "annotation, so there is nothing to build a request model from. "
+            "Either annotate it with a Pydantic model (and install Pydantic "
+            "with: pip install 'pyxle-framework[pydantic]'), or take only "
+            "'request' and read the body yourself with: await request.json().",
+            action=action,
+            source=source,
+        )
+        self.param = param
+
+    def with_identity(self, *, action: str, source: str | None) -> "UnannotatedActionBodyError":
+        return UnannotatedActionBodyError(param=self.param, action=action, source=source)
+
 __all__ = [
     "server",
     "action",
@@ -231,4 +333,7 @@ __all__ = [
     "ValidationActionError",
     "LoaderError",
     "invalidate_routes",
+    "ActionBodyError",
+    "PydanticNotInstalledError",
+    "UnannotatedActionBodyError",
 ]

--- a/tests/compiler/test_parser_diagnostics.py
+++ b/tests/compiler/test_parser_diagnostics.py
@@ -1924,3 +1924,139 @@ class TestAnUnclosedBracketNamesTheBracket:
         errors = [d for d in result.diagnostics if d.section == "python"]
         assert errors and "was never closed" in errors[0].message
         assert errors[0].line == 3
+
+
+class TestActionSignatureValidation:
+    """``pyxle check`` refuses an ``@action`` whose body parameter can never be filled.
+
+    ``pyxle openapi`` already refused these files while ``check`` — the command
+    the deploy guide names as the gate — passed them (P2-30). The rule is read
+    off the AST, so the gate stays static: it never imports the user's module.
+    """
+
+    def _sem(self, text: str):
+        return PyxParser().parse_text(
+            dedent(text).strip("\n"), tolerant=True, validate_semantics=True
+        )
+
+    def _findings(self, text: str):
+        return [
+            d
+            for d in self._sem(text).diagnostics
+            if "no type annotation" in d.message
+        ]
+
+    JSX = """
+
+        import React from 'react'
+
+        export default function P({ data }) {
+            return <div>{data.n}</div>
+        }
+        """
+
+    def _page(self, python: str) -> str:
+        return dedent(python).strip("\n") + "\n" + dedent(self.JSX)
+
+    def test_unannotated_body_parameter_is_an_error(self):
+        findings = self._findings(
+            self._page(
+                """
+                @action
+                async def bump(request, payload):
+                    return {"got": payload}
+
+                @server
+                async def load(request):
+                    return {"n": 1}
+                """
+            )
+        )
+        assert len(findings) == 1
+        assert findings[0].severity == "error"
+        assert findings[0].section == "python"
+        # Names the action and the parameter, and points at the ``def`` line.
+        assert "Action 'bump'" in findings[0].message
+        assert "'payload'" in findings[0].message
+        assert findings[0].line == 2
+
+    def test_message_is_the_dispatchers_own(self):
+        """One writer: the gate quotes ``pyxle.runtime``'s error, not a copy."""
+        from pyxle.runtime import UnannotatedActionBodyError
+
+        findings = self._findings(
+            self._page(
+                """
+                @action
+                async def bump(request, payload):
+                    return {"got": payload}
+                """
+            )
+        )
+        assert findings[0].message == str(
+            UnannotatedActionBodyError(param="payload", action="bump")
+        )
+
+    def test_required_keyword_only_body_parameter_is_an_error(self):
+        findings = self._findings(
+            self._page(
+                """
+                @action
+                async def bump(request, *, payload):
+                    return {"got": payload}
+                """
+            )
+        )
+        assert len(findings) == 1
+
+    @pytest.mark.parametrize(
+        "python",
+        [
+            # The documented single-parameter form.
+            "@action\nasync def bump(request):\n    return {'ok': True}",
+            # Annotated: whether Pydantic is installed is an environment fact a
+            # static gate cannot know, so it is the dispatcher's call, not ours.
+            "@action\nasync def bump(request, payload: Body):\n    return {'ok': True}",
+            # Optional: a default means the call succeeds without a body.
+            "@action\nasync def bump(request, payload=None):\n    return {'ok': True}",
+            "@action\nasync def bump(request, *, payload=None):\n    return {'ok': True}",
+            # Not an action at all — no contract to break.
+            "async def helper(request, whatever):\n    return {'n': 1}",
+            # ``self``/``cls`` are skipped exactly as the dispatcher skips them.
+            "@action\nasync def bump(self, request):\n    return {'ok': True}",
+        ],
+    )
+    def test_valid_shapes_are_not_flagged(self, python):
+        assert self._findings(self._page(python)) == []
+
+    def test_decorator_call_and_attribute_forms_are_recognised(self):
+        for decorator in ("@action()", "@pyxle.action"):
+            findings = self._findings(
+                self._page(
+                    f"""
+                    {decorator}
+                    async def bump(request, payload):
+                        return {{"got": payload}}
+                    """
+                )
+            )
+            assert len(findings) == 1, decorator
+
+    def test_gate_never_imports_the_users_module(self):
+        """The whole point of reading the AST: no import-time side effects.
+
+        A module-level ``raise`` would abort any import-based gate. The static
+        one still reports the signature.
+        """
+        findings = self._findings(
+            self._page(
+                """
+                raise RuntimeError("import-time side effect")
+
+                @action
+                async def bump(request, payload):
+                    return {"got": payload}
+                """
+            )
+        )
+        assert len(findings) == 1

--- a/tests/ssr/test_worker_pool.py
+++ b/tests/ssr/test_worker_pool.py
@@ -1060,7 +1060,11 @@ async def test_pool_invalidate_specific_component() -> None:
 
     assert len(captured) == 1
     assert captured[0]["type"] == "invalidate"
-    assert captured[0]["componentPath"] == str(target.resolve())
+    # ASYNC240 flags the blocking ``resolve()``; here it is an assertion on a
+    # literal path, not event-loop work, and a thread hop would only obscure
+    # what is being compared. Scoped to this line so the rule still guards
+    # the rest of the file.
+    assert captured[0]["componentPath"] == str(target.resolve())  # noqa: ASYNC240
 
     await pool.stop()
 


### PR DESCRIPTION
## Why this exists

`main`'s changelog **already describes this fix**. The code was never committed with it — only the paragraph landed, and **pyxle.dev has been serving that text publicly**. So today a reader follows the changelog, tries it, and gets a green check.

Proved both ways on one scaffolded project rather than by reading the diff:

| package | `pyxle check` on `async def bump(request, payload)` |
|---|---|
| `origin/main` | **"All checks passed", exit 0** |
| this branch | **exit 1**, naming the action, the parameter and the line |

(`origin/main`'s package was extracted read-only with `git archive` and shadowed via `PYTHONPATH` — nothing in the working tree was checked out or reset to measure this.)

## What it does

`pyxle openapi` already refused such a file and said exactly why; `pyxle check` — the command [the deployment guide](docs/guides/deployment.md) names as the gate — did not ask. It asks now, with the same message.

The check reads the shape off the **AST** rather than importing the user's module, so `check` stays static: no import-time side effects, no import errors as a new failure class, no slower gate. Consequently it sees only what the file says, which is the shape the mistake actually takes:

- an **annotated** body parameter is deliberately left alone — whether Pydantic is installed is a fact about the deployment environment, which a static gate cannot know
- a parameter with a **default** is optional and always fine

`ActionBodyError` and its two subclasses move from `pyxle.devserver.validation` to `pyxle.runtime`, beside `@action` itself, so the gate and the dispatcher cannot drift into describing one mistake two ways. They are re-exported from the old module **by name**, so every existing import and `except` clause catches the identical class object. The move (rather than an import where they were) is what keeps `check` off Starlette: importing `pyxle.devserver.validation` costs 261ms and pulls in the chain P2-14 tracks.

## Also included

The **ASYNC240 fix that Dependabot #68 needs to merge green**: `prerender_dir.exists()` is a blocking stat on the startup event loop, now a thread hop; one worker-pool assertion carries a scoped `noqa` because it compares a literal path rather than doing event-loop work.

## Verification

- Full suite **3460 passed**, coverage **96.85%**
- Ruff clean on **0.6.9** (what CI runs today) and **0.16.3** (what #68 brings)
- Checked the static gate agrees with the **live dispatcher** on the awkward case — an action whose first parameter is not called `request`. `resolve_body_model` identifies the request **by name**, not position, and raises on `async def act(req)` exactly as the gate does. Same rule, same message, no false positives.

The changelog is not in this diff because `main` already has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)