### PR TITLE
fix(layouts): STANDALONE on a template stops the wrapper chain too

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,21 @@ Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include
 
 ## Unreleased
 
+- **Fix: `STANDALONE` on a `template.pyxl` now stops the wrapper chain, not just
+  the head and loader chains.** `STANDALONE = True` makes a wrapper the root of
+  its own chain, and three separate walks have to agree on where that root is:
+  the loaders that run, the head contributions that land, and the markup that
+  wraps the page. On a `layout.pyxl` all three stopped. On a `template.pyxl`
+  only two did — the wrapper walk consulted `layout.json` alone and never
+  looked at `template.json`, so a section behind a standalone template had its
+  ancestors' loaders skipped and their head dropped **while their markup still
+  wrapped it.** The page then rendered inside a layout whose loader had never
+  run, so any component of that layout reading its own data found nothing —
+  a wrapper-chain bug that presents as a data bug, in the one place the reader
+  has no reason to look. The rule the other two walks already used is now the
+  only rule: any wrapper, of either kind, declaring `STANDALONE` ends the chain
+  above it. [Layouts](core-concepts/layouts.md#sections-that-are-not-part-of-the-app-standalone).
+
 - **Fix: `pyxle check` no longer passes an action that can never run.**
   An `@action` whose second parameter carries no type annotation —
   `async def bump(request, payload)`, the signature you write without thinking —

--- a/docs/core-concepts/layouts.md
+++ b/docs/core-concepts/layouts.md
@@ -183,7 +183,7 @@ that is exactly wrong. A public status page inside an admin console, a print
 view, an embedded widget: these are not the app, and they should not carry its
 navigation, its stylesheet, its analytics tag, or the cost of its layout loader.
 
-A layout can declare itself the root of its own chain:
+A layout **or a template** can declare itself the root of its own chain:
 
 ```python
 @server
@@ -213,6 +213,10 @@ the loader means an outer layout's query running on every request to a section
 that never renders it. Stopping the loader but not the head means a page that
 opted out of the app shell still inheriting its analytics snippet.
 
+The directive works the same way on a [`template.pyxl`](#templates) as on a
+`layout.pyxl` — a template is a wrapper that remounts, and it stops the chain
+above it exactly as a layout does.
+
 ### Why not just branch in the outer layout
 
 You can write `if (isPublicSection) return <>{children}</>` in your root layout,
@@ -229,7 +233,7 @@ section lose the app shell for no visible reason.
 
 When Pyxle compiles your pages, it:
 
-1. Walks up from each page to the root, collecting `layout.pyxl` and `template.pyxl` files — stopping at any layout that declares `STANDALONE = True`
+1. Walks up from each page to the root, collecting `layout.pyxl` and `template.pyxl` files — stopping at any layout **or template** that declares `STANDALONE = True`
 2. Generates a composed wrapper module that nests them in the correct order
 3. At render time, the page component is passed as `children` to the innermost layout
 

--- a/pyxle/devserver/layouts.py
+++ b/pyxle/devserver/layouts.py
@@ -81,13 +81,31 @@ def _discover_wrappers(relative_dir: Path, settings: DevServerSettings) -> List[
 
 
 def _is_standalone(ancestor: Path, settings: DevServerSettings) -> bool:
-    """Whether the layout in *ancestor* declares itself the root of its chain."""
-    relative = (ancestor / "layout.json") if ancestor != Path(".") else Path("layout.json")
-    metadata_path = settings.metadata_build_dir / "pages" / relative
-    try:
-        return json.loads(metadata_path.read_text()).get("standalone") is True
-    except (OSError, ValueError):
-        return False
+    """Whether a layout **or template** in *ancestor* is the root of its chain.
+
+    Both kinds carry the directive -- the parser reads ``STANDALONE`` from any
+    wrapper -- and both must be read here. This walk used to consult only
+    ``layout.json``, while the head walk
+    (:func:`~pyxle.devserver.registry.find_layout_head_contributions`) and the
+    loader walk (:func:`~pyxle.devserver.registry.find_layout_loaders`) each
+    iterate ``("layout.pyxl", "template.pyxl")``. So a ``template.pyxl``
+    declaring ``STANDALONE`` had its head dropped and its ancestors' loaders
+    skipped, while those same ancestors' **markup still wrapped the page** --
+    the page rendered inside a layout whose loader never ran and whose head was
+    discarded, which surfaces as a component reading its own loader data and
+    finding nothing.
+    """
+    for base_name in _LAYOUT_FILENAMES.values():
+        relative = Path(f"{base_name}.json")
+        if ancestor != Path("."):
+            relative = ancestor / relative
+        metadata_path = settings.metadata_build_dir / "pages" / relative
+        try:
+            if json.loads(metadata_path.read_text()).get("standalone") is True:
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
 
 
 def _apply_wrappers(

--- a/tests/devserver/test_standalone_chain.py
+++ b/tests/devserver/test_standalone_chain.py
@@ -71,6 +71,18 @@ def project(tmp_path):
     )
     metadata("public/status.json")
     metadata("admin/monitors.json")
+    # A standalone **template**, not layout. Templates carry the same directive
+    # and are walked by the same three passes, so they belong in the same
+    # fixture -- the wrapper walk read only `layout.json` and honoured the head
+    # and the loader here while still wrapping the page in the root layout.
+    metadata(
+        "checkout/template.json",
+        loader_name="load",
+        standalone=True,
+        head_jsx_blocks=['<meta name="checkout" content="yes" />'],
+        head=['<style>.checkout{color:green}</style>'],
+    )
+    metadata("checkout/pay.json")
     return settings
 
 
@@ -135,6 +147,32 @@ class TestTheWrapperChain:
             "the root layout still wraps a standalone section"
         )
 
+    def test_discovery_stops_at_a_standalone_template_too(self, project):
+        """`template.pyxl` carries `STANDALONE` exactly as `layout.pyxl` does.
+
+        This walk used to read only `layout.json`, so a standalone template got
+        its head dropped and its ancestors' loaders skipped while their markup
+        still wrapped the page -- it rendered inside a layout whose loader never
+        ran, so any component of that layout reading its own data found nothing.
+        """
+        from pyxle.devserver.layouts import _discover_wrappers
+
+        pages_root = project.client_build_dir / "pages"
+        for relative in ("layout.jsx", "checkout/template.jsx"):
+            path = pages_root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("export default function L({children}){return children}")
+
+        wrappers = _discover_wrappers(Path("checkout"), project)
+        relatives = [str(w.relative_path) for w in wrappers]
+
+        assert any("checkout" in r for r in relatives), (
+            "the standalone template stopped wrapping its own pages"
+        )
+        assert "layout.jsx" not in relatives, (
+            "the root layout still wraps a section behind a standalone template"
+        )
+
     def test_an_ordinary_directory_still_gets_every_ancestor(self, project):
         from pyxle.devserver.layouts import _discover_wrappers
 
@@ -145,3 +183,22 @@ class TestTheWrapperChain:
 
         wrappers = _discover_wrappers(Path("admin"), project)
         assert [str(w.relative_path) for w in wrappers] == ["layout.jsx"]
+
+
+class TestAllThreeWalksAgreeForATemplate:
+    """The module docstring claims all three walks agree. Until the wrapper walk
+    learned about templates that was true for `layout.pyxl` only, and untested
+    for `template.pyxl` -- which is exactly where it was false."""
+
+    def test_the_loader_walk_stops_at_a_standalone_template(self, project):
+        found = find_layout_loaders(project, Path("checkout/pay.pyxl"))
+        paths = [str(info.relative_path) for info in found]
+        assert any("checkout" in p for p in paths)
+        assert "layout.pyxl" not in paths
+
+    def test_the_head_walk_stops_at_a_standalone_template(self, project):
+        contribution = find_layout_head_contributions(project, Path("checkout/pay.pyxl"))
+        assert any("checkout" in b for b in contribution.jsx_blocks)
+        assert not any("analytics" in b for b in contribution.jsx_blocks)
+        assert any(".checkout" in e for e in head_variable(contribution))
+        assert not any(".app" in e for e in head_variable(contribution))


### PR DESCRIPTION
> **Base is `fix/check-unannotated-action` (#76), not `main`**, so this PR shows only its own commit. GitHub retargets it to `main` automatically when #76 merges. The two changes touch disjoint files — the only shared file is the changelog, and this commit adds only its own entry.

## The bug

`STANDALONE = True` makes a wrapper the root of its own chain, and **three** separate walks have to agree on where that root is:

1. which **loaders** run,
2. which **head** contributions land,
3. which **markup** wraps the page.

On a `layout.pyxl` all three stopped. On a `template.pyxl` **only two did.**

`_is_standalone` built its metadata path as `ancestor / "layout.json"` and never looked at `template.json` — while `find_layout_head_contributions` and `find_layout_loaders` each already iterate `("layout.pyxl", "template.pyxl")`.

So a section behind a standalone template had its ancestors' loaders skipped and their head dropped **while their markup still wrapped it.** The page rendered inside a layout whose loader had never run, so any component of that layout reading its own data found nothing — **a wrapper-chain bug that presents as a data bug**, in the one place the reader has no reason to look.

Confirmed reproducing in the published `pyxle-framework==0.9.0`, not just on this branch.

## The fix

One function. It makes the ignorant consumer use the rule the other two already had, so a second rule is **deleted** rather than a third one added.

The stop semantics were checked before being copied rather than assumed: both registry walks `break` *after* processing the ancestor's own layout and template, and `_discover_wrappers` iterates outermost-first and calls `wrappers.clear()` — equivalent. The ordering already matched; only the detection was wrong.

## Verified by running, with controls

Real production server (`pyxle build` + `pyxle serve --skip-build`), against a root `layout.pyxl` carrying a `HEAD` meta, a `@server` loader and a marker `<div>`:

| case | before | after |
|---|---|---|
| standalone **template** — root wrapper `<div>` | **present** ✗ | **absent** ✓ |
| standalone **template** — its own wrapper | present | present ✓ |
| standalone **layout** (control) | correct | **unchanged** ✓ |
| ordinary page, no `STANDALONE` (control) | inherits all three | **unchanged** ✓ |

## Tests

Three, not one. **The new wrapper test bites** — reverting the fix while keeping the tests fails it with `the root layout still wraps a section behind a standalone template`.

The other two assert that the loader and head walks stop at a standalone template. They pass either way, **on purpose**: the test file's docstring claims *"All three walks have to agree"*, and that claim was only ever exercised for `layout.pyxl` — which is exactly where it turned out to be false.

Full suite **3463 passed** (was 3460), coverage **96.84%** held. Ruff clean on **0.6.9** (CI today) and **0.16.3** (what #68 brings).

## Docs

`layouts.md` said only that a *layout* could declare itself the root of its chain; templates were half-supported in code and entirely undocumented. Two ways to close that: reject `STANDALONE` on a template, or document it. Chose to document it — the parser already accepts the directive on any wrapper, two of the three walks already honoured it, and a template is a layout that remounts, so a print view built as one should not be denied what the same file built as a layout gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)