### PR TITLE
Fixes for the failures a new user hits in their first hour

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,145 @@
 
 Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include breaking changes — those are called out explicitly. To upgrade, run `pip install --upgrade pyxle-framework`.
 
+## Unreleased
+
+- **Internal: API modules are imported with the real `debug` flag, not a
+  hardcoded one.** `build_api_router` passed `debug=True` unconditionally, so a
+  production app went through the development module loader. It was inert —
+  only the dev file watcher advances the reload generation and production runs
+  no watcher — but the code described a dev path in a production one, and the
+  next change to make that generation mean something in production would have
+  inherited a silent re-import of every API module. Verified both ways by
+  running: a dev server still picks up an edited `pages/api/*.py` on the next
+  request, and a production `pyxle serve` still answers its API routes.
+
+- **Fix: `/llms.txt` links stay `https://` behind a TLS-terminating proxy.** The
+  absolute URLs were built from the socket's scheme, so an app behind a proxy
+  that speaks plain HTTP to it published a list of `http://` links on an HTTPS
+  site — handed to the one audience that follows them literally. The previous
+  note that "uvicorn's proxy-header support keeps these correct" was true only
+  when the proxy shares the host: uvicorn honours `X-Forwarded-Proto` only from
+  peers in `forwarded_allow_ips` (`127.0.0.1` by default), so an nginx, load
+  balancer or ingress on another host or container sent the header and had it
+  ignored. Measured both ways on one server: from loopback the links came out
+  `https://`, from a non-loopback peer the identical request produced `http://`.
+  Pyxle now reads the header itself. The rule lives in one place and the CSRF
+  cookie's `Secure` decision uses the same function, so the two surfaces cannot
+  drift into disagreeing about whether the client used TLS. A proxy that
+  reports `http` is still taken at its word — the scheme is never guessed
+  upwards.
+
+- **Fix: a freshly scaffolded project's root `vite.config.js` no longer throws.**
+  The scaffold writes one so `shadcn/ui` framework detection, editor
+  integrations and other tools that expect a config at the project root can find
+  it — and it re-exported `.pyxle-build/client/vite.config.js`, which does not
+  exist until the first `pyxle dev` or `pyxle build`. So on a brand-new project
+  the file existed and raised `ERR_MODULE_NOT_FOUND`: the tools it was written
+  for found a config that crashes. It now resolves lazily, returning the
+  generated config once there is one and an empty config before that. A failure
+  *inside* the generated config — a plugin that is not installed — still
+  propagates rather than being flattened into an empty config, which is a
+  distinction the first version of this fix got wrong and a test now pins.
+
+- **Fix: `cookieSameSite: "none"` no longer fails silently on a plain-HTTP
+  origin.** A `SameSite=None` cookie must also be `Secure` — the specification
+  requires the pair, and every current browser rejects the cookie without it.
+  Pyxle deliberately withholds `Secure` over plain HTTP (a `Secure` cookie is
+  dropped there, which would break the form and protect nothing), and that
+  reasoning was applied to `SameSite=None` too — where it cannot work, because
+  the browser drops the cookie either way. Measured in a real browser: on a
+  plain-HTTP dev server with `"none"`, the browser kept **zero** cookies while
+  the page rendered perfectly; with `"lax"` on the same server it kept the CSRF
+  cookie. So the token never reached the client and every `@action` failed its
+  CSRF check, with nothing in the terminal or the console to say why. The
+  header is now spec-correct — `SameSite=None; Secure` always travel together,
+  so devtools names the reason — and the server logs a warning, once, the first
+  time it emits that pair without TLS, saying what will break and how to fix it.
+  `"lax"` and `"strict"` are untouched. [Configuration](reference/configuration.md).
+
+- **Docs fix: the `pyxle routes` sample output did not match what the command
+  prints.** Both the quick-start and the CLI reference reproduced it with the
+  section headers unprefixed and hand-indented, and the CLI reference also wrote
+  page paths as `pages/index.pyxl` where the command prints them relative to
+  `pages/` — contradicting the quick-start's own sentence saying so. Both samples
+  are now the command's real output, captured by running it, and the `routes`
+  test pins the shape instead of only checking that the command said anything.
+
+- **Docs fix: the multi-method API example refused `HEAD`.** The API-routes
+  guide's primary shape — an `endpoint` function branching on `request.method` —
+  tested `== "GET"` and fell through to its own `405` for anything else, so a
+  route copied from our own documentation answered *405 Method Not Allowed* to
+  `curl -I`, uptime monitors, health probers and link checkers. The framework
+  was not at fault and is unchanged: it deliberately lets `HEAD` through to your
+  handler wherever the route accepts `GET`, and the class-based `HTTPEndpoint`
+  alternative in the same guide got this right, which is what made the gap easy
+  to miss. The example now handles `GET` and `HEAD` together and says why, and
+  the note on `enforce_allowed_methods` states the rule. If you copied the old
+  shape, widen that first branch to `if request.method in ("GET", "HEAD")`.
+  [API routes](guides/api-routes.md#http-methods).
+
+- **Fix: a client-side navigation no longer calls your `LoaderError` a server
+  error.** An author-raised `LoaderError` or `ActionError` is deliberate,
+  user-facing copy, and it reaches the visitor verbatim in every environment —
+  that is the point of raising it, and a full page load has always honoured it.
+  A client-side navigation to the same page did not: its JSON payload replaced
+  the message with a generic string and the type with `ServerError`, in
+  production, for *every* failure. So one visitor pasted the URL and read *"That
+  post was deleted in 2019."* while another clicked a link to the same page and
+  read *"The server encountered an error."* — and only the second was wrong. The
+  navigation payload is now built by the same function the HTML boundary uses,
+  rather than a second copy of the rule that had drifted from it, so an
+  author-raised message, its `data`, and its status all arrive intact. Nothing
+  loosened for anything else: a non-author exception is still replaced with a
+  generic string and `ServerError` in production, with the exception's own class
+  name withheld. [Error handling](guides/error-handling.md#what-the-visitor-sees-and-what-you-see).
+
+- **Fix: every module imports on its own again.** `import pyxle.ssr.view` and
+  `import pyxle.ssr.template` raised `ImportError: ... most likely due to a
+  circular import` from a cold interpreter. `pyxle/devserver/__init__.py`
+  imported `starlette_app` at module scope, `starlette_app` imports `pyxle.ssr`,
+  and `pyxle.ssr` imports back into `pyxle.devserver` for `dev_origins` and
+  `error_pages` — so entering the cycle from the SSR side found a half-built
+  module. It never affected a running app, because `import pyxle` and the CLI
+  both enter from the other side; what it broke was reading one module on its
+  own, which is what a contributor, an editor, or a documentation tool does
+  first. The one import that closed the loop is now made where it is used.
+
+- **An occupied port now explains itself, before anything expensive happens.**
+  A port already in use is the most common way a dev server fails to start, and
+  it was the least legible failure we shipped: uvicorn's own
+  `[Errno 98] error while attempting to bind ... address already in use`, with
+  no remedy and no suggestion of a port that would work. It also arrived at the
+  wrong moment in both commands. `pyxle dev` had already started Vite, so the
+  **last** line on screen was `[vite] process exited with code 143` — the
+  shutdown of an innocent child — and the eye lands on the last line. `pyxle
+  serve` had already rebuilt the whole project, and had already printed
+  `Serving Pyxle build on http://host:port`, a success line with a clickable
+  URL, for a server that never bound. Both commands now check the port first —
+  before Vite, before `npm install`, before any build — and say which port is
+  taken, what usually holds it, a free port to use instead, and the command that
+  names the process squatting on it. `pyxle serve` on a taken port now fails in
+  well under a second instead of after a full build. The port you asked for is
+  still never silently changed; only Vite's own port moves on its own.
+  [CLI reference](reference/cli.md#pyxle-dev).
+
+- **Fix: the dev error document no longer calls a deliberate 404 a crash.**
+  `LoaderError` and `ActionError` take a `status_code` precisely so your code
+  can *decline* a request — a missing post is a `404`, a signed-out visitor a
+  `401` — and the response Pyxle sent carried that status correctly. The page
+  the **developer** saw did not: it was headed **Server Render Failed** under
+  the title *Pyxle • Error* whatever the status, so the person building a
+  deliberate 404 was told the server had broken while their visitor was told
+  the truth — the inverse of the audience each message suits. The dev document
+  now reads by status, the way the production one already did: a sub-500 is
+  headed with the wording a visitor would get and says the response was one
+  your code chose, and only a 5xx is still headed *Server Render Failed*. The
+  class decides rather than a table, so a 4xx nobody has written specific
+  wording for is still never described as a server fault. Everything a
+  developer needs is unchanged — exception type, message, the file and line of
+  the `raise`, and the Vite client tag that reloads the page when you fix it.
+  [Error handling](guides/error-handling.md#what-the-visitor-sees-and-what-you-see).
+
 ## 0.9.1
 
 - **Fix: `STANDALONE` on a `template.pyxl` now stops the wrapper chain, not just

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -128,11 +128,11 @@ This prints the route table derived from your `pages/` directory:
 ```
 ℹ️  Routes for my-app/
 
-  Pages:
-  ▶️  / — index.pyxl  [loader=load_home]
+ℹ️    Pages:
+▶️  / — index.pyxl  [loader=load_home]
 
-  API Routes:
-  ▶️  /api/pulse — api/pulse.py
+ℹ️    API Routes:
+▶️  /api/pulse — api/pulse.py
 
 ✅ 2 route(s) found
 ```

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -30,7 +30,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 async def endpoint(request: Request) -> JSONResponse:
-    if request.method == "GET":
+    if request.method in ("GET", "HEAD"):
         users = await fetch_all_users()
         return JSONResponse({"users": users})
 
@@ -42,7 +42,9 @@ async def endpoint(request: Request) -> JSONResponse:
     return JSONResponse({"error": "Method not allowed"}, status_code=405)
 ```
 
-For multi-method endpoints with automatic `405 Method Not Allowed` handling, use an `HTTPEndpoint` class (below) — Starlette dispatches each request to the matching `get`/`post`/… method and rejects the rest.
+**Handle `HEAD` wherever you handle `GET`.** [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-head) defines `HEAD` as identical to `GET` without a response body, and it is what `curl -I`, uptime monitors, health probers and link checkers send. Pyxle deliberately lets `HEAD` through to your handler whenever the route accepts `GET` — so if your own branch only tests `== "GET"`, the request falls past it to your `405`, and the route you advertise as a `GET` endpoint refuses half the clients that would use it. The server strips the body from a `HEAD` response for you; returning the full `JSONResponse` is correct.
+
+For multi-method endpoints with automatic `405 Method Not Allowed` handling, use an `HTTPEndpoint` class (below) — Starlette dispatches each request to the matching `get`/`post`/… method and rejects the rest. A class-based endpoint gets the `HEAD` behaviour above for free: Starlette dispatches `HEAD` to `get` unless you define a `head` method.
 
 ## Using HTTPEndpoint classes
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -173,6 +173,27 @@ So it is split:
 Design `error.pyxl` for the production wording. Rendering `{error.message}` is
 fine, but do not build the page around it saying something specific.
 
+This holds however the visitor arrived. A client-side navigation fetches the
+page as JSON rather than HTML, and that payload is built from the same rule —
+so clicking a link to a failing page and pasting its URL give the boundary the
+same `message`, `type`, `statusCode` and `data`. (They did not always: the
+navigation path carried its own copy of the rule and had lost the author-raised
+exemption, so a clicked link reported `ServerError` for a `LoaderError` a pasted
+URL reported correctly.)
+
+#### The fallback document reads by status, in dev as well as production
+
+When no `error.pyxl` answers, Pyxle serves its own fallback document, and what
+it says is decided by the **status** — because a `LoaderError(status_code=404)`
+is your code stating a fact about the request, not a fault. A sub-500 fallback
+is headed with the same wording a visitor would get (*Not found*, *Sign in
+required*, *Too many requests*), and says in as many words that the response
+was one your code chose. Only a 5xx is headed *Server Render Failed*.
+
+In `pyxle dev` that document still carries everything you need to find the
+`raise` — the exception type, its message, and the file and line in your
+`.pyxl` — so nothing is lost by it no longer calling a deliberate 404 a crash.
+
 ### An `error.pyxl` does not run a loader
 
 Unlike `not-found.pyxl`, an error page has **no** `@server` loader: it receives

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -163,7 +163,7 @@ for downstream middleware.
 Pyxle applies two default hooks:
 
 - **`attach_route_metadata`** -- adds route info to `request.scope["pyxle"]["route"]`
-- **`enforce_allowed_methods`** -- returns 405 for disallowed API methods
+- **`enforce_allowed_methods`** -- returns 405 for disallowed API methods. `HEAD` is allowed wherever `GET` is, per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-head), so health probers and `curl -I` are never refused by this hook.
 
 ## Rate limiting
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -123,6 +123,27 @@ pyxle dev ./my-app --print-config
 pyxle dev --verbose             # troubleshoot: full Vite + debug output
 ```
 
+**If the port is taken.** `pyxle dev` and `pyxle serve` check the port before
+they start anything — before Vite, before `npm install`, and before a build — so
+an occupied port costs you a message rather than a build:
+
+```
+❌ Port 8000 is already in use, so pyxle dev cannot start.
+
+Something is already listening on 127.0.0.1:8000 — most often a pyxle dev from
+an earlier session that is still running, or another application using the same
+port.
+
+Start on a free port:   pyxle dev --port 8001
+See what is holding it: lsof -i :8000
+```
+
+The suggested port is one that was free when the message was written; nothing is
+reserved. Note that only the **Vite** port moves on its own (`Vite port 5173 in
+use; retrying on 5174`) — the port you asked for is never silently changed,
+because a server quietly listening somewhere other than where you pointed your
+browser is worse than one that did not start.
+
 **What it does:**
 
 1. Loads configuration from `pyxle.config.json` + environment variables + CLI flags
@@ -389,18 +410,18 @@ pyxle routes [directory] [options]
 ```
 ℹ️  Routes for my-app/
 
-  Pages:
-  ▶️  /  — pages/index.pyxl  [loader=load_home]
-  ▶️  /about  — pages/about.pyxl
-  ▶️  /blog/{slug}  — pages/blog/[slug].pyxl  [loader=load_post]
+ℹ️    Pages:
+▶️  / — index.pyxl  [loader=load_home]
+▶️  /about — about.pyxl
+▶️  /blog/{slug} — blog/[slug].pyxl  [loader=load_post]
 
-  API Routes:
-  ▶️  /api/pulse  — pages/api/pulse.py
+ℹ️    API Routes:
+▶️  /api/pulse — api/pulse.py
 
-  Special Files (no URL of their own):
-  ▶️  error boundary — error.pyxl  [covers /]
-  ▶️  404 page — not-found.pyxl  [covers /]
-  ▶️  loading fallback — blog/loading.pyxl  [covers /blog/*]
+ℹ️    Special Files (no URL of their own):
+▶️  error boundary — error.pyxl  [covers /]
+▶️  404 page — not-found.pyxl  [covers /]
+▶️  loading fallback — blog/loading.pyxl  [covers /blog/*]
 
 ✅ 4 route(s) found
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -216,7 +216,18 @@ Route-level hooks applied to specific route types.
 | `csrf.cookieName` | `string` | auto: `"pyxle-csrf-<port>"` | CSRF cookie name; unset → namespaced by the app's bind port |
 | `csrf.headerName` | `string` | `"x-csrf-token"` | CSRF header name |
 | `csrf.cookieSecure` | `boolean` | `false` | Set `Secure` flag on cookie |
-| `csrf.cookieSameSite` | `string` | `"lax"` | `SameSite` attribute (`"strict"`, `"lax"`, `"none"`) |
+| `csrf.cookieSameSite` | `string` | `"lax"` | `SameSite` attribute (`"strict"`, `"lax"`, `"none"`). **`"none"` requires HTTPS** — see the note below. |
+
+> **`cookieSameSite: "none"` only works over HTTPS.** The cookie specification
+> requires a `SameSite=None` cookie to also be `Secure`, and every current
+> browser drops a `Secure` cookie delivered over plain HTTP — so on an HTTP
+> origin the CSRF cookie is discarded before your code ever sees it. The page
+> still renders perfectly; every `@action` then fails its CSRF check, which is
+> exactly the failure that leaves nothing to search for. Pyxle now sends the
+> spec-correct `SameSite=None; Secure` pair and logs a warning the first time it
+> does so without TLS, naming the consequence. If you are behind a
+> TLS-terminating proxy, make sure it sets `X-Forwarded-Proto: https` — that is
+> what Pyxle reads to know the connection was secure. Otherwise use `"lax"`.
 | `csrf.exemptPaths` | `string[]` | `[]` | Paths exempt from CSRF checks (matched on segment boundaries) |
 
 **Cookie naming.** Browsers scope cookies to a host, ignoring the port, so a fixed cookie name would collide between two Pyxle apps on the same host (e.g. two dev servers on `127.0.0.1`) — each would overwrite the other's token and every action in the other app would fail with `403`. When `cookieName` is unset, Pyxle namespaces the cookie with the app's bind port (`pyxle-csrf-8000`), which is stable per app in development and behind a production reverse proxy. Set `cookieName` to pin an explicit name instead. Full details and the upgrade note: [Security → CSRF protection](../guides/security.md#csrf-protection).

--- a/pyxle/cli/__init__.py
+++ b/pyxle/cli/__init__.py
@@ -884,6 +884,17 @@ def _dev_impl(
         f" with Vite proxy at http://{settings.vite_host}:{settings.vite_port}"
     )
 
+    # Before debugpy, before Vite, before npm install and before the first
+    # build: an occupied port is the most common way this command fails, and
+    # every one of those steps makes the eventual message harder to read (see
+    # pyxle.devserver.ports).
+    _require_free_port(
+        logger,
+        settings.starlette_host,
+        settings.starlette_port,
+        command="pyxle dev",
+    )
+
     # debugpy setup is synchronous (~0.4s, spawns the adapter subprocess) and
     # must happen before the event loop starts — never inside a coroutine. The
     # optional wait-for-attach is deferred into the server run so it happens
@@ -923,6 +934,25 @@ def _dev_impl(
         raise typer.Exit(code=1) from exc
     finally:
         _restore_sigterm_handler(previous_sigterm)
+
+
+def _require_free_port(logger, host: str, port: int, *, command: str) -> None:
+    """Stop with a legible message when ``host:port`` is already listening.
+
+    Called before anything expensive or anything that spawns a child, so the
+    explanation is the only thing on screen — see :mod:`pyxle.devserver.ports`
+    for why the position in the sequence is half the fix.
+    """
+    from pyxle.devserver.ports import (  # noqa: PLC0415 - startup path, keep it lazy
+        is_port_available,
+        port_in_use_message,
+    )
+
+    if is_port_available(host, port):
+        return
+
+    logger.error(port_in_use_message(host, port, command=command))
+    raise typer.Exit(code=1)
 
 
 def _start_debug_server(logger, *, port: int) -> tuple:
@@ -1357,6 +1387,19 @@ def serve(
     except (GlobalStyleConfigError, GlobalScriptConfigError) as exc:
         logger.error(str(exc))
         raise typer.Exit(code=1) from exc
+
+    # Checked before the build and before the multi-worker branch below: this
+    # command rebuilds the project on the way up, and discovering the port is
+    # taken on the far side of that costs the developer the whole build for a
+    # failure that was knowable immediately. It also keeps the "Serving Pyxle
+    # build on ..." line honest — that line used to print, with a clickable
+    # URL, for a server that then failed to bind.
+    _require_free_port(
+        logger,
+        settings.starlette_host,
+        settings.starlette_port,
+        command="pyxle serve",
+    )
 
     if not skip_build:
         # A fresh build runs Vite and requires the supported Node.js floor.

--- a/pyxle/devserver/__init__.py
+++ b/pyxle/devserver/__init__.py
@@ -9,7 +9,7 @@ import socket
 import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import uvicorn
 
@@ -25,7 +25,6 @@ from .dev_origins import (
 from .registry import build_metadata_registry
 from .routes import RouteTable, build_route_table
 from .settings import DevServerSettings
-from .starlette_app import create_starlette_app
 from .tailwind import TailwindProcess, detect_postcss_config, detect_tailwind_config
 from .vite import ViteProcess
 from .watcher import ProjectWatcher, WatcherStatistics
@@ -169,7 +168,19 @@ class DevServer:
                     vite_owns_css=vite_owns_stylesheets(settings),
                 )
 
-            app = create_starlette_app(settings, route_table, logger=logger, pool=_pool)
+            # Resolved through the package object, not a direct submodule
+            # import, for two reasons at once. Deferring it is what breaks the
+            # import cycle (see ``__getattr__`` at the bottom of this module).
+            # Reading it as an *attribute of this package* is what keeps
+            # ``monkeypatch.setattr("pyxle.devserver.create_starlette_app", ...)``
+            # working: a patched attribute lives in the module ``__dict__`` and
+            # is found before ``__getattr__`` is ever consulted, so the seam the
+            # tests use survives the fix.
+            from pyxle import devserver as _package  # noqa: PLC0415
+
+            app = _package.create_starlette_app(
+                settings, route_table, logger=logger, pool=_pool
+            )
             # Seed the gate from the startup build, so a page that was already
             # broken before the server started is refused from the first
             # request rather than only after the next save.
@@ -893,3 +904,22 @@ def _maybe_schedule_reload(overlay, loop, stats: WatcherStatistics) -> bool:
 
 
 __all__ = ["DevServer", "DevServerSettings", "ProjectWatcher"]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose ``create_starlette_app`` without importing it at module scope.
+
+    ``starlette_app`` imports ``pyxle.ssr``, which imports back into this
+    package for ``dev_origins`` and ``error_pages``. Importing it eagerly here
+    made that cycle real: ``import pyxle.ssr.view`` from a cold interpreter
+    found a partially initialised module and raised. Resolving it on first
+    attribute access breaks the edge while leaving the name exactly where every
+    existing caller and test expects to find it.
+
+    Same pattern as :mod:`pyxle.ssr`, which defers its own heavy submodules.
+    """
+    if name == "create_starlette_app":
+        from .starlette_app import create_starlette_app  # noqa: PLC0415
+
+        return create_starlette_app
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/pyxle/devserver/csrf.py
+++ b/pyxle/devserver/csrf.py
@@ -77,16 +77,14 @@ _logger = logging.getLogger(__name__)
 def _is_https(scope: Scope) -> bool:
     """Whether this request reached us over TLS.
 
-    Reads ``X-Forwarded-Proto`` first, because the overwhelmingly common
-    production shape is a TLS-terminating proxy speaking plain HTTP to the app
-    — where the ASGI scheme says ``http`` and the *browser's* connection was
-    HTTPS all along. Falls back to the scheme the server itself sees.
+    Delegates to :func:`pyxle.devserver.dev_origins.request_is_https` so the
+    forwarded-proto rule lives in exactly one place. ``/llms.txt`` needs the
+    same answer to build absolute URLs, and a second copy of this logic is how
+    two surfaces end up disagreeing about whether the client used HTTPS.
     """
-    for name, value in scope.get("headers", ()):
-        if name == b"x-forwarded-proto":
-            first = value.decode("latin-1").split(",")[0].strip().lower()
-            return first == "https"
-    return str(scope.get("scheme", "")).lower() in ("https", "wss")
+    from pyxle.devserver.dev_origins import request_is_https  # noqa: PLC0415
+
+    return request_is_https(scope)
 
 
 class CsrfMiddleware:
@@ -141,6 +139,7 @@ class CsrfMiddleware:
         self._cookie_secure = cookie_secure
         self._cookie_samesite = cookie_samesite
         self._exempt_paths: tuple[str, ...] = tuple(exempt_paths)
+        self._warned_samesite_none = False
 
         if not self._secret:
             _logger.warning(
@@ -262,17 +261,51 @@ class CsrfMiddleware:
                 # public`; those routes render no per-user data and any
                 # state-changing actions on them must be CSRF-exempt.
                 if not _is_public_cacheable(headers):
+                    https = _is_https(scope)
+                    samesite_none = self._cookie_samesite.lower() == "none"
                     cookie_value = (
                         f"{cookie_name}={token}; Path=/"
                         f"; SameSite={self._cookie_samesite}"
                     )
-                    if self._cookie_secure and _is_https(scope):
+                    # ``SameSite=None`` *must* carry ``Secure``: the spec
+                    # requires the pair, and every current browser rejects the
+                    # cookie without it. The ``_is_https`` guard below exists
+                    # because withholding ``Secure`` keeps a plain-HTTP cookie
+                    # alive — true for ``lax``/``strict``, and impossible for
+                    # ``none``, which the browser drops either way. Sending the
+                    # spec-correct header at least makes devtools say why.
+                    if samesite_none or (self._cookie_secure and https):
                         cookie_value += "; Secure"
+                    if samesite_none and not https:
+                        self._warn_samesite_none_over_http()
                     headers.append((b"set-cookie", cookie_value.encode("latin-1")))
                     message = {**message, "headers": headers}
             await send(message)
 
         await self.app(scope, downstream_receive, send_with_cookie)
+
+    def _warn_samesite_none_over_http(self) -> None:
+        """Say, once, that this cookie is being thrown away by the browser.
+
+        ``cookieSameSite: "none"`` on a plain-HTTP origin is not a weaker
+        setting — it is a *broken* one. The browser discards the cookie, the
+        double-submit token never reaches the client, and every ``@action``
+        fails its CSRF check while the page itself renders perfectly. That is
+        the same shape as the ``Secure``-over-HTTP bug this middleware already
+        guards against: nothing errors, so there is nothing to search for.
+        """
+        if self._warned_samesite_none:
+            return
+        self._warned_samesite_none = True
+        _logger.warning(
+            "CsrfMiddleware: csrf.cookieSameSite is 'none' but this request "
+            "did not arrive over HTTPS. A SameSite=None cookie must also be "
+            "Secure, and a Secure cookie is dropped over plain HTTP — so the "
+            "CSRF cookie is being discarded by the browser and every @action "
+            "will fail its CSRF check with no error of its own. Serve over "
+            "HTTPS (or set X-Forwarded-Proto on your TLS-terminating proxy), "
+            "or use csrf.cookieSameSite 'lax'."
+        )
 
     def _is_exempt(self, path: str) -> bool:
         """Return ``True`` when ``path`` is CSRF-exempt.

--- a/pyxle/devserver/dev_origins.py
+++ b/pyxle/devserver/dev_origins.py
@@ -89,6 +89,34 @@ VITE_DEFAULT_ORIGIN_PATTERN: Final[str] = (
 DEV_SESSION_FILENAME: Final[str] = "dev-server.json"
 
 
+def forwarded_scheme(scope: Any) -> str:
+    """The scheme the *client* used, not the one our socket saw.
+
+    Reads ``X-Forwarded-Proto`` first, because the overwhelmingly common
+    production shape is a TLS-terminating proxy speaking plain HTTP to the app:
+    the ASGI scheme says ``http`` while the browser's connection was HTTPS all
+    along.
+
+    We do this ourselves rather than leaning on uvicorn's proxy-header support,
+    which only rewrites the scheme when the peer address is in
+    ``forwarded_allow_ips`` -- ``127.0.0.1`` by default. That covers a proxy on
+    the same host and silently does nothing for the equally ordinary shape of
+    an nginx / load balancer / ingress on a different host or container, where
+    the header arrives and is ignored.
+    """
+    for name, value in scope.get("headers", ()):
+        if name == b"x-forwarded-proto":
+            first = value.decode("latin-1").split(",")[0].strip().lower()
+            return "https" if first == "https" else "http"
+    scheme = str(scope.get("scheme", "")).lower()
+    return "https" if scheme in ("https", "wss") else "http"
+
+
+def request_is_https(scope: Any) -> bool:
+    """Whether the client's connection was TLS -- see :func:`forwarded_scheme`."""
+    return forwarded_scheme(scope) == "https"
+
+
 def is_wildcard_host(host: str) -> bool:
     """Whether ``host`` binds every interface rather than a named address."""
 

--- a/pyxle/devserver/layouts.py
+++ b/pyxle/devserver/layouts.py
@@ -46,15 +46,25 @@ def _iter_page_metadata(metadata_dir: Path) -> Iterable[tuple[Path, Path]]:
 
 
 def _discover_wrappers(relative_dir: Path, settings: DevServerSettings) -> List[WrapperSpec]:
-    """Every layout and template that wraps a page, closest first.
+    """Every layout and template that wraps a page, **outermost first**.
 
-    Stops at a layout declaring ``STANDALONE = True``: that layout is the root
-    of its own chain, so nothing above it applies. The case is a section of a
-    site that is not part of the app around it — a public status page inside an
-    admin console, a print view, an embedded widget — where the alternative is
-    teaching the outer layout to recognise each such section and render
-    nothing, a conditional that grows a branch per child and puts knowledge of
-    every one of them in the parent.
+    That is the order they nest in, and the order the caller composes them in:
+    the root ``layout.pyxl`` comes first and the page's own directory last. (It
+    used to say "closest first", which is backwards — ``_ancestor_dirs`` walks
+    root-downwards and each wrapper is appended as it is found.)
+
+    A wrapper declaring ``STANDALONE = True`` — a ``layout.pyxl`` **or** a
+    ``template.pyxl`` — becomes the root of its own chain, so nothing above it
+    applies. Mechanically it *discards* what has been collected rather than
+    stopping the walk: everything found before it is an ancestor it has declared
+    it does not want, and the walk still has to continue downwards to collect
+    the wrappers between it and the page.
+
+    The case is a section of a site that is not part of the app around it — a
+    public status page inside an admin console, a print view, an embedded widget
+    — where the alternative is teaching the outer layout to recognise each such
+    section and render nothing, a conditional that grows a branch per child and
+    puts knowledge of every one of them in the parent.
     """
     client_pages_root = settings.client_build_dir / "pages"
     ancestors = _ancestor_dirs(relative_dir)

--- a/pyxle/devserver/llms.py
+++ b/pyxle/devserver/llms.py
@@ -954,14 +954,21 @@ def make_llms_txt_route(routes: RouteTable, *, settings: Any) -> Route:
     Resolution order: a static ``public/llms.txt`` (served by the static-asset
     middleware before this route ever runs) → a ``llms_txt`` hook in the root
     ``pages/llms.py`` → a generated index of the app's pages. Generated links
-    are absolute, derived from the request's scheme and host (uvicorn's
-    proxy-header support keeps these correct behind a reverse proxy).
+    are absolute, derived from the client's scheme (``X-Forwarded-Proto``
+    where present) and host, so they stay ``https://`` behind a TLS-terminating
+    proxy on any host -- not only one uvicorn happens to trust.
     """
     config = getattr(settings, "llms", None)
 
     async def handler(request: Request) -> Response:
         debug = bool(getattr(settings, "debug", False))
-        base_url = f"{request.url.scheme}://{request.url.netloc}"
+        # The client's scheme, not the socket's: behind a TLS-terminating
+        # proxy on another host these links were emitted as ``http://`` on an
+        # HTTPS site -- a downgrade handed to the exact audience, agents, that
+        # follows them literally.
+        from pyxle.devserver.dev_origins import forwarded_scheme  # noqa: PLC0415
+
+        base_url = f"{forwarded_scheme(request.scope)}://{request.url.netloc}"
 
         def render_default() -> str:
             return build_llms_txt(

--- a/pyxle/devserver/ports.py
+++ b/pyxle/devserver/ports.py
@@ -1,0 +1,93 @@
+"""Deciding whether a TCP port is free, and saying so usefully when it is not.
+
+An occupied port is the most common way a dev server fails to start, and it was
+the least legible failure we shipped. uvicorn's own
+``[Errno 98] error while attempting to bind ... address already in use`` arrived
+with no framework voice, no remedy, and no suggestion of a port that *would*
+work. Worse, it arrived at the wrong moment in both commands:
+
+* ``pyxle dev`` had already spawned Vite, so the **last** line on screen was
+  ``[vite] process exited with code 143`` — the SIGTERM of an innocent child
+  during teardown. The eye lands on the last line, and it named the one
+  component that had done nothing wrong.
+* ``pyxle serve`` had already rebuilt the project, and had already printed
+  ``Serving Pyxle build on http://host:port`` — a success line, with a URL the
+  developer could click, for a server that never bound.
+
+So the check happens *first*, before Vite starts and before anything is built:
+a failure that costs nothing to detect should not cost a rebuild to discover.
+
+Stdlib only, deliberately — this is imported on the startup path of every
+command that binds a socket.
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+from typing import Final
+
+#: How far above the requested port to look for a free one to suggest.
+_SUGGESTION_SEARCH_LIMIT: Final[int] = 20
+
+#: How long to wait for a connection probe before calling the port free. A
+#: listener on the loopback or LAN answers far inside this.
+_PROBE_TIMEOUT_SECONDS: Final[float] = 0.1
+
+
+def is_port_available(host: str, port: int) -> bool:
+    """Whether nothing is currently listening on ``host:port``.
+
+    Probes by connecting rather than binding: binding to test would either race
+    with the real bind moments later, or (with ``SO_REUSEADDR``) succeed against
+    a socket in ``TIME_WAIT`` that a server could still legitimately use.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(_PROBE_TIMEOUT_SECONDS)
+        return sock.connect_ex((host, port)) != 0
+
+
+def find_free_port(
+    host: str, start: int, limit: int = _SUGGESTION_SEARCH_LIMIT
+) -> int | None:
+    """The first free port at or above ``start``, or ``None`` if there is none.
+
+    Used only to *suggest* a port. Nothing is reserved — by the time the
+    developer runs the suggested command the port could be taken again, which is
+    no worse than the guess they would otherwise make themselves.
+    """
+    for candidate in range(start, start + limit):
+        if candidate > 65535:
+            return None
+        if is_port_available(host, candidate):
+            return candidate
+    return None
+
+
+def _holder_hint(port: int) -> str:
+    """A command that names the process holding ``port``, for this platform."""
+    if sys.platform.startswith("win"):
+        return f"netstat -ano | findstr :{port}"
+    return f"lsof -i :{port}"
+
+
+def port_in_use_message(host: str, port: int, *, command: str) -> str:
+    """Explain that ``host:port`` is taken, and what to do about it.
+
+    ``command`` is the command the developer ran (``"pyxle dev"``), so the
+    remedy is a line they can paste rather than a flag they have to place.
+    """
+    lines = [
+        f"Port {port} is already in use, so {command} cannot start.",
+        "",
+        f"Something is already listening on {host}:{port} — most often a "
+        f"{command} from an earlier session that is still running, or another "
+        "application using the same port.",
+    ]
+
+    free_port = find_free_port(host, port + 1)
+    if free_port is not None:
+        lines += ["", f"Start on a free port:   {command} --port {free_port}"]
+
+    lines += [f"See what is holding it: {_holder_hint(port)}"]
+    return "\n".join(lines)

--- a/pyxle/devserver/starlette_app.py
+++ b/pyxle/devserver/starlette_app.py
@@ -570,14 +570,25 @@ def build_api_router(
     routes: Iterable[ApiRoute],
     *,
     route_hooks: Sequence[RouteHookCallable] | None = None,
+    debug: bool = False,
 ) -> Router:
-    """Create a Starlette ``Router`` populated from compiled API artifacts."""
+    """Create a Starlette ``Router`` populated from compiled API artifacts.
+
+    ``debug`` selects the module loader's dev behaviour — re-importing a module
+    once a rebuild has advanced the reload generation. It used to be hardcoded
+    ``True`` here, which was inert in production (only the dev file watcher ever
+    calls ``mark_rebuild``, and production runs no watcher) but described the
+    wrong thing to anyone reading it. Passing the real flag costs nothing and
+    stops the code claiming a dev path in a production one.
+    """
 
     router = Router()
     hooks = list(route_hooks or [])
 
     for route in routes:
-        module = _import_module(route.module_key, route.server_module_path, debug=True)
+        module = _import_module(
+            route.module_key, route.server_module_path, debug=debug
+        )
         http_handler, ws_handler = _resolve_api_handlers(module)
         context = RouteContext(
             target="api",
@@ -1772,6 +1783,7 @@ def _build_app_routes(
     api_router = build_api_router(
         routes.apis,
         route_hooks=[*DEFAULT_API_POLICIES, *api_route_hooks],
+        debug=settings.debug,
     )
     page_router = build_page_router(
         routes.pages,

--- a/pyxle/ssr/template.py
+++ b/pyxle/ssr/template.py
@@ -621,6 +621,47 @@ def _origin_in_user_source(
     return None
 
 
+def _dev_error_copy(
+    status_code: int, *, page_path: str, error_type: str
+) -> tuple[str, str, str, str]:
+    """Title, heading, lead and hint for the dev error document.
+
+    A 5xx is a crash and reads as one. A sub-500 is not: ``LoaderError`` and
+    ``ActionError`` take a ``status_code`` precisely so a loader can *decline* a
+    request — a missing post is a 404, a signed-out visitor a 401 — and the
+    response Pyxle sends carries that status correctly. The developer's own page
+    said ``Server Render Failed`` anyway, so the person building a deliberate
+    404 was told the server had broken while their visitor was told the truth:
+    the inverse of the audience each message suits.
+
+    The heading is the one production would show for the same status, so dev and
+    prod agree on *what happened*; everything a crash page carries — exception
+    type, message, file and line, the Vite client tag — stays, because the
+    developer still needs to find the ``raise``.
+    """
+    if status_code >= 500:
+        return (
+            "Pyxle • Error",
+            "Server Render Failed",
+            f"While rendering <code>{page_path}</code>, Pyxle encountered a "
+            f"<strong>{error_type}</strong>.",
+            "Check your loader or component implementation. The server terminal "
+            "carries the full traceback.",
+        )
+
+    heading, detail = _status_document(status_code)
+    return (
+        f"Pyxle • {status_code} {heading}",
+        heading,
+        f"<code>{page_path}</code> raised <strong>{error_type}</strong> with "
+        f"status <strong>{status_code}</strong>. Pyxle answered with that "
+        "status — this is a response your code chose, not a crash.",
+        f"A visitor sees “{detail}” To answer this with your own "
+        "page instead, add an <code>error.pyxl</code> beside the route or "
+        "anywhere up its directory tree.",
+    )
+
+
 def render_error_document(
     *,
     settings: DevServerSettings,
@@ -682,21 +723,25 @@ def render_error_document(
             f"line {origin_line}</span>{source_markup}</div>"
         )
 
+    title, heading, lead, hint = _dev_error_copy(
+        status_code, page_path=page_path, error_type=error_type
+    )
+
     return f"""<!DOCTYPE html>
 <html lang=\"en\">
   <head>
     <meta charset=\"utf-8\" />
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-    <title>Pyxle • Error</title>
+    <title>{title}</title>
     <script type=\"module\" src=\"{vite_origin}/@vite/client\"></script>
 {_ERROR_DOCUMENT_STYLES}
   </head>
   <body>
     <main class=\"pyxle-error\">
-      <h1>Server Render Failed</h1>
-      <p>While rendering <code>{page_path}</code>, Pyxle encountered a <strong>{error_type}</strong>.</p>
+      <h1>{heading}</h1>
+      <p>{lead}</p>
       <pre>{message}</pre>{origin_markup}
-      <p>Check your loader or component implementation. The server terminal carries the full traceback.</p>
+      <p>{hint}</p>
     </main>
   </body>
 </html>

--- a/pyxle/ssr/view.py
+++ b/pyxle/ssr/view.py
@@ -1601,8 +1601,14 @@ def _build_error_context(
     path, row ID, or secret. In production (``debug=False``) such messages are
     replaced with a generic string so an ``error.pyxl`` boundary never leaks
     internals (CLAUDE.md rule 18); in development they are surfaced (redacted
-    for obvious secrets, mirroring the dev error overlay and
-    :func:`_navigation_error_response`).
+    for obvious secrets, mirroring the dev error overlay).
+
+    :func:`_navigation_error_response` builds its JSON payload from this same
+    function. It used to carry its own copy of the rule, and the copy had lost
+    the author-raised exemption — so a client-side navigation to a page whose
+    loader raised ``LoaderError("...", status_code=404)`` received
+    ``"ServerError"`` while a full load of the same page rendered the author's
+    own copy. One rule, one place, so they cannot drift again.
     """
     from pyxle.runtime import ActionError, LoaderError
 
@@ -1655,25 +1661,30 @@ async def _navigation_error_response(
     # Navigation errors return JSON, so they need the same production
     # sanitization the HTML error document applies (CLAUDE.md rule 18): an
     # exception message may carry file paths, row IDs, or secrets, and a
-    # client must never receive them. In dev we surface the detail (redacted
-    # for obvious secrets, mirroring the dev error overlay) to aid debugging.
-    if settings.debug:
-        from pyxle.devserver._security import redact_sensitive_patterns  # noqa: PLC0415
-
-        error_message = redact_sensitive_patterns(str(error) or error.__class__.__name__)
-        error_type = error.__class__.__name__
-    else:
-        error_message = "The server encountered an error while processing this request."
-        error_type = "ServerError"
+    # client must never receive them.
+    #
+    # Built by the *same* function the HTML boundary uses, rather than a second
+    # copy of the rule. The two had drifted: ``_build_error_context`` passes an
+    # author-raised LoaderError/ActionError through verbatim in every
+    # environment — which is what the error-handling guide promises and what a
+    # full page load did — while this path replaced it with "ServerError" and a
+    # generic string. So the same 404 answered one way when the visitor pasted
+    # the URL and another way when they clicked a link to it, and only the
+    # clicked one was wrong.
+    error_context = _build_error_context(error, status_code, debug=settings.debug)
 
     payload = {
         "ok": False,
         "routePath": page.path,
         "requestedPath": request.url.path,
         "stage": stage,
-        "error": error_message,
-        "errorType": error_type,
+        "error": error_context["message"],
+        "errorType": error_context["type"],
     }
+    # An author-raised error may carry a ``data`` payload written for the
+    # boundary to render; the HTML path already delivers it.
+    if "data" in error_context:
+        payload["data"] = error_context["data"]
     return JSONResponse(payload, status_code=status_code)
 
 

--- a/pyxle/templates/scaffold/vite.config.js
+++ b/pyxle/templates/scaffold/vite.config.js
@@ -7,4 +7,31 @@
 // detection, editor integrations, and other tools that expect a config at the
 // project root — can find one. You normally never edit this file; run
 // `pyxle dev` / `pyxle build` rather than `vite` directly.
-export { default } from './.pyxle-build/client/vite.config.js';
+//
+// It re-exports *lazily*, and that is deliberate: `.pyxle-build/` does not
+// exist until the first `pyxle dev` or `pyxle build`, so a static
+// `export { default } from ...` made this file throw ERR_MODULE_NOT_FOUND on a
+// freshly scaffolded project — meaning the very tools it exists to satisfy
+// found a config that crashes. Vite accepts a function returning a config, so
+// resolution is deferred to the moment something actually asks.
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export default async () => {
+    const generated = join(
+        dirname(fileURLToPath(import.meta.url)),
+        '.pyxle-build',
+        'client',
+        'vite.config.js',
+    );
+    // Existence is checked rather than catching ERR_MODULE_NOT_FOUND, because
+    // that error cannot be told apart from the one it must not hide: when the
+    // generated config imports a plugin that is not installed, Node names the
+    // generated file in the message too — as the *importer*. Catching on the
+    // message swallowed a genuine "plugin missing" failure into an empty
+    // config. Not built yet is a file that is not there; anything else is a
+    // real error and travels.
+    if (!existsSync(generated)) return {};
+    return (await import(pathToFileURL(generated).href)).default;
+};

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import socket
 import subprocess
 import sys
 from pathlib import Path
@@ -398,6 +399,83 @@ def test_run_subprocess_handles_missing_binary(monkeypatch, tmp_path) -> None:
 
     with pytest.raises(typer.Exit):
         cli._run_subprocess(["npm", "install"], cwd=tmp_path, label="Node", logger=logger)
+
+
+def test_serve_refuses_an_occupied_port_before_building_anything(monkeypatch) -> None:
+    """The check has to come *before* the build, or it costs a build to learn.
+
+    ``pyxle serve`` rebuilds the project on the way up. Discovering the port is
+    taken on the far side of that made the developer pay a full build for a
+    failure that was knowable in milliseconds — and printed
+    ``Serving Pyxle build on http://host:port``, a success line with a clickable
+    URL, for a server that then failed to bind.
+    """
+    built: list[str] = []
+    monkeypatch.setattr(cli, "run_build", lambda *a, **k: built.append("built"))
+
+    with runner.isolated_filesystem():
+        project = Path("demo")
+        (project / "pages").mkdir(parents=True)
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+            port = sock.getsockname()[1]
+
+            result = runner.invoke(
+                app,
+                ["serve", "demo", "--host", "127.0.0.1", "--port", str(port)],
+            )
+        finally:
+            sock.close()
+
+    assert result.exit_code == 1
+    assert "already in use" in result.stdout
+    assert str(port) in result.stdout
+    # The whole point: nothing was built, and no URL was advertised.
+    assert built == []
+    assert "Serving Pyxle build on" not in result.stdout
+
+
+def test_dev_refuses_an_occupied_port_before_starting_anything(monkeypatch) -> None:
+    """Same, one step earlier: before Vite, npm install and the first build.
+
+    With Vite already spawned, the *last* line on screen was
+    ``[vite] process exited with code 143`` — the SIGTERM of an innocent child
+    during teardown — so the most prominent message named the one component
+    that had done nothing wrong.
+    """
+    started: list[str] = []
+
+    class ExplodingDevServer:
+        def __init__(self, *a, **k):
+            started.append("constructed")
+
+    monkeypatch.setattr(cli, "DevServer", ExplodingDevServer)
+
+    with runner.isolated_filesystem():
+        project = Path("demo")
+        (project / "pages").mkdir(parents=True)
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+            port = sock.getsockname()[1]
+
+            result = runner.invoke(
+                app,
+                ["dev", "demo", "--host", "127.0.0.1", "--port", str(port)],
+            )
+        finally:
+            sock.close()
+
+    assert result.exit_code == 1
+    assert "already in use" in result.stdout
+    assert started == []
+    # uvicorn's raw errno is what this replaced; it must not survive alongside.
+    assert "Errno 98" not in result.stdout
 
 
 def test_serve_command_runs_build_and_uvicorn(monkeypatch) -> None:
@@ -2151,6 +2229,17 @@ def test_routes_command_shows_page_routes() -> None:
 
         assert result.exit_code == 0
         assert "route(s) found" in result.stdout
+        # Pin the shape the docs print verbatim. Both `quick-start.md` and
+        # `reference/cli.md` reproduce this output as a sample, and both had
+        # drifted from it: they showed the section headers unprefixed and
+        # hand-indented, and `cli.md` additionally wrote page paths as
+        # `pages/index.pyxl` while the command prints them relative to
+        # `pages/` — which quick-start's own prose already said. Nothing
+        # compared the samples to reality, so asserting only "route(s) found"
+        # let every one of those drift silently.
+        assert "\u2139\ufe0f    Pages:" in result.stdout
+        assert "\u25b6\ufe0f  /about \u2014 about.pyxl" in result.stdout
+        assert "pages/about.pyxl" not in result.stdout
 
 
 def test_routes_command_json_output() -> None:

--- a/tests/cli/test_scaffold.py
+++ b/tests/cli/test_scaffold.py
@@ -103,3 +103,69 @@ def test_validate_project_name_rejects_a_path() -> None:
 
     # A plain name is untouched, and `.` still means "scaffold in place".
     assert validate_project_name("my-app") == "my-app"
+
+
+# ---------------------------------------------------------------------------
+# The root vite.config.js — it exists to be found by other people's tools, so
+# it has to survive being imported before anything has been built.
+# ---------------------------------------------------------------------------
+
+
+def _node() -> str | None:
+    import shutil
+
+    return shutil.which("node")
+
+
+@pytest.mark.skipif(_node() is None, reason="needs Node.js to import an ES module")
+def test_scaffolded_root_vite_config_imports_before_any_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh project's root Vite config must not throw.
+
+    The scaffold writes it so ``shadcn/ui`` framework detection, editor
+    integrations and other tools that expect a config at the project root can
+    find one. It re-exports ``.pyxle-build/client/vite.config.js`` — which does
+    not exist until the first ``pyxle dev`` / ``pyxle build``. A static
+    re-export therefore threw ``ERR_MODULE_NOT_FOUND`` on every freshly
+    scaffolded project, so the tools it exists to satisfy found a config that
+    crashes.
+    """
+    import json
+    import subprocess
+
+    from typer.testing import CliRunner
+
+    from pyxle.cli import app
+
+    runner = CliRunner()
+    # `pyxle init` takes a *name* and creates it in the cwd — passing a path is
+    # refused with a message saying exactly that.
+    monkeypatch.chdir(tmp_path)
+    project = tmp_path / "demo"
+    result = runner.invoke(app, ["init", "demo", "--yes"], catch_exceptions=False)
+    assert result.exit_code == 0, result.stdout
+
+    config = project / "vite.config.js"
+    assert config.exists()
+    assert not (project / ".pyxle-build").exists(), "nothing should be built yet"
+
+    proc = subprocess.run(
+        [
+            _node(),
+            "-e",
+            "import('./vite.config.js')"
+            ".then(async (m) => { const c = await m.default();"
+            " process.stdout.write(JSON.stringify(c)); })"
+            ".catch((e) => { process.stderr.write(String(e.code || e.message));"
+            " process.exit(1); })",
+        ],
+        cwd=project,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"a freshly scaffolded root vite.config.js failed to import: {proc.stderr}"
+    )
+    # Nothing is built, so it resolves to an empty config rather than throwing.
+    assert json.loads(proc.stdout or "{}") == {}

--- a/tests/devserver/test_csrf.py
+++ b/tests/devserver/test_csrf.py
@@ -741,6 +741,62 @@ class TestCookieAndScopeBehavior:
         assert downstream_called == ["lifespan"]
 
 
+def _build_app_with_samesite(value: str) -> Starlette:
+    async def get_handler(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    return Starlette(
+        routes=[Route("/page", get_handler, methods=["GET"])],
+        middleware=[
+            Middleware(CsrfMiddleware, secret="s", cookie_samesite=value),
+        ],
+    )
+
+
+class TestSameSiteNoneIsAlwaysPairedWithSecure:
+    """``SameSite=None`` without ``Secure`` is a cookie the browser throws away.
+
+    Verified in a real headless Firefox before the fix: with
+    ``cookieSameSite: "none"`` on a plain-HTTP dev server the browser kept
+    **zero** cookies while the page rendered perfectly — and with ``lax`` on the
+    same server it kept the CSRF cookie. So the token never reaches the client
+    and every ``@action`` fails its CSRF check, with nothing in the terminal or
+    the console to say why.
+
+    The fix cannot make ``None`` *work* over HTTP — nothing can. It makes the
+    header spec-correct so devtools names the reason, and warns once.
+    """
+
+    def test_samesite_none_carries_secure_even_without_tls(self):
+        client = TestClient(_build_app_with_samesite("none"), base_url="http://testserver")
+        set_cookie = client.get("/page").headers.get("set-cookie", "")
+        assert "SameSite=none" in set_cookie
+        assert "Secure" in set_cookie
+
+    def test_samesite_none_over_plain_http_warns_once(self, caplog):
+        client = TestClient(_build_app_with_samesite("none"), base_url="http://testserver")
+        with caplog.at_level("WARNING", logger="pyxle.devserver.csrf"):
+            for _ in range(4):
+                client.get("/page")
+        hits = [r for r in caplog.records if "cookieSameSite is 'none'" in r.getMessage()]
+        assert len(hits) == 1, f"expected exactly one warning, got {len(hits)}"
+        assert "@action" in hits[0].getMessage()
+
+    def test_lax_over_plain_http_is_untouched(self, caplog):
+        """The guard: the existing ``Secure``-withholding behaviour must stand.
+
+        Withholding ``Secure`` over HTTP is deliberate and load-bearing for
+        ``lax``/``strict`` — it is what keeps a plain-HTTP production server's
+        forms working. Widening the ``None`` fix into those must fail here.
+        """
+        client = TestClient(_build_app_with_samesite("lax"), base_url="http://testserver")
+        with caplog.at_level("WARNING", logger="pyxle.devserver.csrf"):
+            set_cookie = client.get("/page").headers.get("set-cookie", "")
+        assert "SameSite=lax" in set_cookie
+        assert "Secure" not in set_cookie
+        assert not [r for r in caplog.records if "cookieSameSite" in r.getMessage()]
+
+
 def _build_app_with_secure_cookie() -> Starlette:
     async def get_handler(request: Request) -> PlainTextResponse:
         return PlainTextResponse("ok")

--- a/tests/devserver/test_dev_origins.py
+++ b/tests/devserver/test_dev_origins.py
@@ -435,3 +435,59 @@ def test_vite_reachability_warning_names_a_pinned_host_it_can_see() -> None:
 
     assert message is not None
     assert "http://192.168.1.11:3000/" in message
+
+
+# ---------------------------------------------------------------------------
+# The client's scheme vs the socket's. One rule, used by both the CSRF cookie
+# and the absolute URLs in /llms.txt.
+# ---------------------------------------------------------------------------
+
+
+def _scope(*, scheme: str = "http", forwarded: str | None = None) -> dict:
+    headers = []
+    if forwarded is not None:
+        headers.append((b"x-forwarded-proto", forwarded.encode()))
+    return {"type": "http", "scheme": scheme, "headers": headers}
+
+
+class TestForwardedScheme:
+    """Measured before this existed: with a proxy on *another* host, uvicorn
+    ignores ``X-Forwarded-Proto`` (the peer is not in ``forwarded_allow_ips``,
+    ``127.0.0.1`` by default) and ``/llms.txt`` emitted ``http://`` links on an
+    HTTPS site. Reading the header ourselves is what makes the answer the same
+    wherever the proxy runs."""
+
+    def test_forwarded_https_wins_over_a_plain_socket(self):
+        from pyxle.devserver.dev_origins import forwarded_scheme
+
+        assert forwarded_scheme(_scope(scheme="http", forwarded="https")) == "https"
+
+    def test_forwarded_http_is_not_upgraded(self):
+        """A proxy that says http means http — never guess upwards."""
+        from pyxle.devserver.dev_origins import forwarded_scheme
+
+        assert forwarded_scheme(_scope(scheme="http", forwarded="http")) == "http"
+
+    def test_first_hop_wins_in_a_comma_list(self):
+        from pyxle.devserver.dev_origins import forwarded_scheme
+
+        assert forwarded_scheme(_scope(forwarded="https, http")) == "https"
+
+    def test_falls_back_to_the_socket_scheme(self):
+        from pyxle.devserver.dev_origins import forwarded_scheme
+
+        assert forwarded_scheme(_scope(scheme="https")) == "https"
+        assert forwarded_scheme(_scope(scheme="http")) == "http"
+
+    def test_csrf_uses_the_same_rule(self):
+        """The two surfaces must never disagree about whether this was TLS."""
+        from pyxle.devserver.csrf import _is_https
+        from pyxle.devserver.dev_origins import request_is_https
+
+        for scope in (
+            _scope(scheme="http", forwarded="https"),
+            _scope(scheme="http", forwarded="http"),
+            _scope(scheme="https"),
+            _scope(scheme="http"),
+        ):
+            assert _is_https(scope) is request_is_https(scope)

--- a/tests/devserver/test_ports.py
+++ b/tests/devserver/test_ports.py
@@ -1,0 +1,67 @@
+"""An occupied port has to explain itself — see :mod:`pyxle.devserver.ports`."""
+
+from __future__ import annotations
+
+import socket
+from contextlib import contextmanager
+
+from pyxle.devserver.ports import (
+    find_free_port,
+    is_port_available,
+    port_in_use_message,
+)
+
+
+@contextmanager
+def occupied_port():
+    """Listen on an ephemeral port and yield it, so nothing is hard-coded."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def test_is_port_available_sees_a_real_listener() -> None:
+    with occupied_port() as port:
+        assert is_port_available("127.0.0.1", port) is False
+
+
+def test_is_port_available_is_true_once_the_listener_is_gone() -> None:
+    with occupied_port() as port:
+        pass
+    assert is_port_available("127.0.0.1", port) is True
+
+
+def test_find_free_port_steps_over_an_occupied_one() -> None:
+    with occupied_port() as port:
+        assert find_free_port("127.0.0.1", port) != port
+
+
+def test_find_free_port_gives_up_rather_than_running_past_the_port_range() -> None:
+    assert find_free_port("127.0.0.1", 65535, limit=5) in (65535, None)
+
+
+def test_the_message_names_the_port_the_command_and_a_way_out() -> None:
+    """The three things a developer needs, none of which the errno carried."""
+    with occupied_port() as port:
+        message = port_in_use_message("127.0.0.1", port, command="pyxle dev")
+
+    assert str(port) in message
+    assert "already in use" in message
+    assert "pyxle dev" in message
+    # A port that actually works, not just an instruction to pick one.
+    assert "--port" in message
+    # And a way to find the process squatting on it.
+    assert str(port) in message.splitlines()[-1]
+
+
+def test_the_message_suggests_a_port_that_is_genuinely_free() -> None:
+    with occupied_port() as port:
+        message = port_in_use_message("127.0.0.1", port, command="pyxle serve")
+        suggested = int(message.split("--port ")[1].split()[0])
+
+    assert suggested != port
+    assert is_port_available("127.0.0.1", suggested)

--- a/tests/devserver/test_starlette_app.py
+++ b/tests/devserver/test_starlette_app.py
@@ -18,6 +18,7 @@ from pyxle.cli.logger import ConsoleLogger
 from pyxle.devserver.build_errors import BuildFailure
 from pyxle.devserver.builder import build_once
 from pyxle.devserver.registry import load_metadata_registry
+from pyxle.devserver.route_hooks import DEFAULT_API_POLICIES
 from pyxle.devserver.routes import build_route_table
 from pyxle.devserver.settings import DevServerSettings
 from pyxle.devserver.starlette_app import (
@@ -102,6 +103,88 @@ def test_build_api_router_registers_function_and_class(project: DevServerSetting
     response = client.get("/api/posts/42")
     assert response.status_code == 200
     assert response.json() == {"id": "42"}
+
+
+def test_api_modules_are_imported_with_the_real_debug_flag(
+    project: DevServerSettings, monkeypatch
+) -> None:
+    """Production must not import API modules through the dev loader.
+
+    ``build_api_router`` hardcoded ``debug=True``. It was inert — only the dev
+    file watcher advances the reload generation and production runs no watcher —
+    but the code claimed a dev path in a production one, and the next person to
+    make the generation mean something in production would have inherited a
+    silent re-import of every API module.
+    """
+    from pyxle.devserver import starlette_app as sa
+
+    seen: list[bool] = []
+    real = sa._import_module
+
+    def spy(module_key, module_path, *, debug=False):
+        seen.append(debug)
+        return real(module_key, module_path, debug=debug)
+
+    monkeypatch.setattr(sa, "_import_module", spy)
+
+    write_file(
+        project.pages_dir / "api/ping.py",
+        "from starlette.responses import JSONResponse\n\n"
+        "async def endpoint(request):\n"
+        "    return JSONResponse({'ok': True})\n",
+    )
+    build_once(project)
+    table = build_route_table(load_metadata_registry(project))
+
+    seen.clear()
+    sa.build_api_router(table.apis, debug=False)
+    assert seen and not any(seen), f"production import used debug={seen}"
+
+    seen.clear()
+    sa.build_api_router(table.apis, debug=True)
+    assert all(seen), f"dev import lost its debug flag: {seen}"
+
+
+def test_head_reaches_a_function_endpoint_instead_of_405(
+    project: DevServerSettings,
+) -> None:
+    """The whole chain has to deliver HEAD, not just the hook that permits it.
+
+    Three separate things must agree: ``_API_HTTP_METHODS`` has to contain
+    ``GET`` so Starlette adds ``HEAD`` to the route, the route has to match,
+    and ``enforce_allowed_methods`` has to let it past. The hook is unit-tested
+    on its own; this pins the chain, because the failure mode is somebody
+    editing the method tuple and every hook test still passing.
+
+    It matters because ``curl -I``, uptime monitors, health probers and link
+    checkers all send ``HEAD`` — answering 405 refuses them on a route
+    advertised as ``GET``.
+    """
+    write_file(
+        project.pages_dir / "api/widgets.py",
+        "from starlette.responses import JSONResponse\n\n"
+        "async def endpoint(request):\n"
+        "    return JSONResponse({'method': request.method})\n",
+    )
+    build_once(project)
+    registry = load_metadata_registry(project)
+    table = build_route_table(registry)
+
+    # DEFAULT_API_POLICIES, not a bare router: enforce_allowed_methods is the
+    # hook that decides HEAD, and a router built without hooks never runs it —
+    # which is exactly the hole this test existed to close on its first draft.
+    app = Starlette()
+    app.router.routes.extend(
+        build_api_router(table.apis, route_hooks=DEFAULT_API_POLICIES).routes
+    )
+    client = TestClient(app)
+
+    assert client.get("/api/widgets").status_code == 200
+    head = client.head("/api/widgets")
+    assert head.status_code == 200, "HEAD was refused on a route that accepts GET"
+    # The handler really ran and saw HEAD — it is not GET in disguise, so a
+    # handler branching on request.method must test for it (docs/guides/api-routes.md).
+    assert client.get("/api/widgets").json() == {"method": "GET"}
 
 
 def test_private_module_beside_an_endpoint_boots_and_stays_importable(

--- a/tests/ssr/test_module_imports.py
+++ b/tests/ssr/test_module_imports.py
@@ -1,0 +1,46 @@
+"""Every module has to be importable on its own, from a cold interpreter.
+
+``pyxle.devserver`` and ``pyxle.ssr`` import each other: the dev server builds
+the Starlette app out of SSR, and SSR reaches back for ``dev_origins`` and
+``error_pages``. While ``pyxle/devserver/__init__.py`` pulled in
+``starlette_app`` at module scope that cycle was real, and entering it from the
+SSR side raised — ``import pyxle.ssr.view`` and ``import pyxle.ssr.template``
+both failed on a partially initialised module.
+
+It stayed invisible because ``import pyxle`` and the CLI both enter from the
+other side, so nothing we run day to day ever tripped it. What it broke was a
+contributor importing one module to look at it, and any tool that does the same.
+
+These run in a **subprocess** on purpose: inside the pytest process the modules
+are already in ``sys.modules``, and the cycle only bites on a cold import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+#: One per edge of the cycle, plus the modules either side of it.
+STANDALONE_MODULES = [
+    "pyxle.ssr.view",
+    "pyxle.ssr.template",
+    "pyxle.ssr.renderer",
+    "pyxle.ssr.worker_pool",
+    "pyxle.devserver",
+    "pyxle.devserver.starlette_app",
+    "pyxle.devserver.error_pages",
+]
+
+
+@pytest.mark.parametrize("module", STANDALONE_MODULES)
+def test_module_imports_standalone_in_a_cold_interpreter(module: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"`import {module}` failed in a fresh interpreter:\n{result.stderr}"
+    )

--- a/tests/ssr/test_template.py
+++ b/tests/ssr/test_template.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from pyxle.devserver.routes import PageRoute
+from pyxle.runtime import LoaderError
 from pyxle.devserver.settings import DevServerSettings
 from pyxle.ssr.renderer import InlineStyleFragment
 from pyxle.ssr.template import render_document, render_error_document, render_head_markup
@@ -795,6 +796,73 @@ def test_render_error_document_dev_mode_includes_details(
     assert "[REDACTED_SECRET]" in html
     assert page_route.path in html
     assert "@vite/client" in html
+
+
+def test_dev_error_document_does_not_call_a_declined_request_a_crash(
+    page_route: PageRoute, tmp_path: Path
+) -> None:
+    """A sub-500 is a response the author chose, and must not read as a crash.
+
+    ``LoaderError`` takes a ``status_code`` so a loader can decline a request —
+    a missing post is a 404. The response carried that status correctly while
+    the developer's own page was headed *Server Render Failed*, so the person
+    building a deliberate 404 was told the server had broken while their
+    visitor was told the truth.
+    """
+    settings = DevServerSettings.from_project_root(tmp_path)  # debug=True
+    error = LoaderError("No such post", status_code=404)
+
+    html = render_error_document(
+        settings=settings, page=page_route, error=error, status_code=404
+    )
+
+    assert "Server Render Failed" not in html
+    assert "<h1>Not found</h1>" in html
+    assert "not a crash" in html
+    # Everything the developer needs to find the raise is still here.
+    assert "LoaderError" in html
+    assert "No such post" in html
+    assert page_route.path in html
+    assert "@vite/client" in html
+
+
+def test_dev_error_document_still_calls_a_real_failure_a_crash(
+    page_route: PageRoute, tmp_path: Path
+) -> None:
+    """The 5xx document is unchanged — a crash is still reported as one."""
+    settings = DevServerSettings.from_project_root(tmp_path)  # debug=True
+
+    html = render_error_document(
+        settings=settings,
+        page=page_route,
+        error=RuntimeError("genuinely broken"),
+        status_code=500,
+    )
+
+    assert "<h1>Server Render Failed</h1>" in html
+    assert "<title>Pyxle \u2022 Error</title>" in html
+    assert "genuinely broken" in html
+
+
+def test_dev_error_document_never_blames_the_server_for_an_unmapped_4xx(
+    page_route: PageRoute, tmp_path: Path
+) -> None:
+    """A 4xx with no specific wording is still not described as a server fault.
+
+    The *class* decides, not the table — so adding wording for a status is a
+    refinement rather than a bug fix nobody remembers to make.
+    """
+    settings = DevServerSettings.from_project_root(tmp_path)  # debug=True
+
+    html = render_error_document(
+        settings=settings,
+        page=page_route,
+        error=LoaderError("teapot", status_code=418),
+        status_code=418,
+    )
+
+    assert "Server Render Failed" not in html
+    assert "<h1>Request not accepted</h1>" in html
 
 
 def test_render_error_document_production_mode_redacts_internals(

--- a/tests/ssr/test_view.py
+++ b/tests/ssr/test_view.py
@@ -1553,6 +1553,121 @@ async def test_build_page_navigation_response_loader_error_uses_status_code(
     assert "Forbidden" in payload["error"]
 
 
+def _nav_page_raising(tmp_path: Path, raise_source: str, module_stem: str) -> PageRoute:
+    """A page whose loader raises whatever *raise_source* says."""
+    server_module = tmp_path / "server" / f"{module_stem}.py"
+    server_module.parent.mkdir(parents=True, exist_ok=True)
+    server_module.write_text(
+        "from pyxle.runtime import ActionError, LoaderError\n"
+        "async def my_loader(request):\n"
+        f"    {raise_source}\n",
+        encoding="utf-8",
+    )
+    return PageRoute(
+        path="/nav",
+        source_relative_path=Path("nav.pyxl"),
+        source_absolute_path=tmp_path / "pages" / "nav.pyxl",
+        server_module_path=server_module,
+        client_module_path=tmp_path / "client" / "nav.jsx",
+        metadata_path=tmp_path / "metadata" / "nav.json",
+        module_key=f"pyxle.server.pages.{module_stem}",
+        client_asset_path="/pages/nav.jsx",
+        server_asset_path="/pages/nav.py",
+        content_hash="hash",
+        loader_name="my_loader",
+        loader_line=2,
+        head_elements=(),
+        head_is_dynamic=False,
+    )
+
+
+async def _nav_payload(page: PageRoute, settings: DevServerSettings) -> dict:
+    response = await build_page_navigation_response(
+        request=Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/nav",
+                "query_string": b"",
+                "headers": [],
+            }
+        ),
+        settings=settings,
+        page=page,
+        renderer=StubRenderer(),
+        overlay=StubOverlay(),
+    )
+    return json.loads(await _read_response_body(response)), response.status_code
+
+
+@pytest.mark.asyncio
+async def test_navigation_delivers_an_author_raised_message_in_production(
+    settings: DevServerSettings, tmp_path: Path
+) -> None:
+    """Clicking a link must answer the same as pasting the URL.
+
+    An author-raised ``LoaderError`` is deliberate, user-facing copy, and the
+    error-handling guide promises it reaches the visitor *verbatim in every
+    environment*. A full page load honoured that. A client-side navigation to
+    the same page replaced it with ``"ServerError"`` and a generic string — so
+    the identical 404 read one way when the URL was pasted and another when the
+    link was clicked, and only the clicked one was wrong.
+    """
+    page = _nav_page_raising(
+        tmp_path,
+        "raise LoaderError('That post was deleted in 2019.', status_code=404)",
+        "nav_author_prod",
+    )
+
+    payload, status = await _nav_payload(page, replace(settings, debug=False))
+
+    assert status == 404
+    assert payload["error"] == "That post was deleted in 2019."
+    assert payload["errorType"] == "LoaderError"
+
+
+@pytest.mark.asyncio
+async def test_navigation_carries_an_author_raised_data_payload(
+    settings: DevServerSettings, tmp_path: Path
+) -> None:
+    """``LoaderError(data=...)`` is written for the boundary to render."""
+    page = _nav_page_raising(
+        tmp_path,
+        "raise LoaderError('Gone', status_code=410, data={'slug': 'hello'})",
+        "nav_author_data",
+    )
+
+    payload, _ = await _nav_payload(page, replace(settings, debug=False))
+
+    assert payload["data"] == {"slug": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_navigation_still_hides_a_non_author_exception_in_production(
+    settings: DevServerSettings, tmp_path: Path
+) -> None:
+    """The reason the sanitization exists, and it must survive the fix.
+
+    A guard, not a proof — this passed before the change too. It is here so
+    that widening the author-raised exemption can never quietly widen to
+    everything (CLAUDE.md rule 18).
+    """
+    page = _nav_page_raising(
+        tmp_path,
+        "raise RuntimeError('row 4471 at /srv/secrets/app.db key=sk_live_ABC')",
+        "nav_leak_prod",
+    )
+
+    payload, status = await _nav_payload(page, replace(settings, debug=False))
+    raw = json.dumps(payload)
+
+    assert status == 500
+    assert payload["errorType"] == "ServerError"
+    assert payload["error"] == "An unexpected error occurred."
+    for secret in ("sk_live_ABC", "srv/secrets", "row 4471", "RuntimeError"):
+        assert secret not in raw
+
+
 def test_normalize_head_entries_none_returns_empty(tmp_path: Path) -> None:
     """_normalize_head_entries(page, None) returns an empty tuple."""
     from pyxle.ssr.view import _normalize_head_entries
@@ -3595,7 +3710,15 @@ async def test_build_page_navigation_response_enriches_browser_global_error(
 async def test_build_page_navigation_response_browser_global_error_generic_in_production(
     settings: DevServerSettings, tmp_path: Path
 ) -> None:
-    """The production nav-error JSON leaks neither the global nor the file."""
+    """The production nav-error JSON leaks neither the global nor the file.
+
+    The expected string changed when the nav path started building its payload
+    with ``_build_error_context``, the same function the HTML boundary uses.
+    This path had its own generic wording; the shared one is what the
+    error-handling guide documents as the production value. What this test is
+    actually for — that nothing internal escapes — is unchanged, and still
+    asserted below.
+    """
     prod_settings = replace(settings, debug=False)
     page = _page_route(tmp_path, loader_name=None)
     renderer = _failing_renderer("localStorage is not defined")
@@ -3612,7 +3735,7 @@ async def test_build_page_navigation_response_browser_global_error_generic_in_pr
     payload = json.loads(raw)
     assert response.status_code == 500
     assert payload["errorType"] == "ServerError"
-    assert payload["error"] == "The server encountered an error while processing this request."
+    assert payload["error"] == "An unexpected error occurred."
     assert "localStorage" not in raw
     assert "pyxl" not in raw
     assert "useEffect" not in raw

--- a/tests/ssr/test_view.py
+++ b/tests/ssr/test_view.py
@@ -1600,7 +1600,7 @@ async def _nav_payload(page: PageRoute, settings: DevServerSettings) -> dict:
     return json.loads(await _read_response_body(response)), response.status_code
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_navigation_delivers_an_author_raised_message_in_production(
     settings: DevServerSettings, tmp_path: Path
 ) -> None:
@@ -1626,7 +1626,7 @@ async def test_navigation_delivers_an_author_raised_message_in_production(
     assert payload["errorType"] == "LoaderError"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_navigation_carries_an_author_raised_data_payload(
     settings: DevServerSettings, tmp_path: Path
 ) -> None:
@@ -1642,7 +1642,7 @@ async def test_navigation_carries_an_author_raised_data_payload(
     assert payload["data"] == {"slug": "hello"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_navigation_still_hides_a_non_author_exception_in_production(
     settings: DevServerSettings, tmp_path: Path
 ) -> None:

--- a/tests/ssr/test_worker_pool.py
+++ b/tests/ssr/test_worker_pool.py
@@ -1086,8 +1086,17 @@ async def test_pool_invalidate_tolerates_dead_workers() -> None:
     for w in pool._workers:
         w.alive = False
 
-    # Should not raise.
+    proc.stdin.write.reset_mock()
     await pool.invalidate()
+
+    # "Tolerates" is not the claim worth pinning — not raising would also be
+    # true of an invalidate that wrote to a dead worker's closed pipe and
+    # swallowed the error. The behaviour is that it *skips* it, so nothing is
+    # written at all.
+    assert proc.stdin.write.call_count == 0, (
+        "invalidate() wrote to a worker it had been told was dead"
+    )
+
     await pool.stop()
 
 
@@ -1099,8 +1108,22 @@ async def test_pool_invalidate_before_start_is_noop() -> None:
         project_root=Path("/tmp/proj"),
         client_root=Path("/tmp/proj/client"),
     )
-    # Should not raise.
-    await pool.invalidate()
+
+    # A no-op has to be observable as one: the interesting failure is not an
+    # exception, it is an invalidate that quietly *starts* the pool — spawning
+    # Node processes from a call that is supposed to do nothing.
+    #
+    # Honest label: this is a GUARD, not a proof. Deleting the ``_started``
+    # check does not fail it, and cannot — with no workers to iterate, the
+    # unguarded loop writes nothing either. It bites only on a change that
+    # makes invalidate *spawn*, which is the regression worth naming. Said
+    # plainly so nobody reads a passing run here as evidence the guard is
+    # covered.
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as spawn:
+        await pool.invalidate()
+
+    assert spawn.call_count == 0, "invalidate() on an unstarted pool spawned a worker"
+    assert pool._workers == []
 
 
 def _setup_dynamic_invalidation_response(

--- a/tests/test_docs_python_samples.py
+++ b/tests/test_docs_python_samples.py
@@ -1,0 +1,96 @@
+"""Every Python sample we publish has to be Python.
+
+A syntax error in a documented sample is a defect a test suite will never catch
+on its own: nothing imports the docs, so a broken snippet ships, gets copied,
+and fails in a stranger's terminal on their first ten minutes with the
+framework. This walks every ``python`` fence under ``docs/`` and parses it.
+
+Three kinds of block are deliberately not parsed as pure Python, and each skip
+is a rule rather than a list of whatever currently fails:
+
+* **A whole ``.pyxl`` file.** These are fenced ``python`` on purpose — pyxle.dev
+  detects the Python→JS boundary and upgrades them to its dual tokenizer (see
+  ``looksLikePyxl`` in the site's ``code-highlighter.jsx``). The JSX half is not
+  Python and is not supposed to be.
+* **An abridged block**, marked with ``...`` or ``…``. The ellipsis is the
+  author telling the reader it is not complete.
+* **A one-line signature display**, e.g. ``LoaderError(message: str, ...)`` —
+  reference material describing a call, not a statement to run.
+
+Anything else must parse. Two truncated excerpts of real framework source are
+allowlisted by name below, with the reason.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+DOCS_ROOT = Path(__file__).resolve().parent.parent / "docs"
+
+#: The first top-level JS import or export — the Python→JS boundary in a
+#: ``.pyxl`` file. Kept in step with the site's own ``PYXL_JS_BOUNDARY``.
+_JS_BOUNDARY = re.compile(
+    r"^import\b.*\bfrom\s+['\"]|^export\s+(default|function|const|class|async|let|var)\b",
+    re.M,
+)
+
+_SIGNATURE_LINE = re.compile(r"^[A-Za-z_][\w.]*\(.*\)\s*$", re.S)
+
+#: Truncated excerpts of real source, shown deliberately mid-definition in the
+#: architecture notes. Parsing them would require inventing a body the reader is
+#: not meant to see. Keyed by ``path:line`` so moving one makes the skip fail
+#: loudly instead of silently covering a new block.
+_ALLOWED_TRUNCATED = {
+    "architecture/compiler.md": "compile_file's signature, shown without its body",
+    "architecture/parser.md": "_JSX_TOPLEVEL_PREFIXES, shown partially",
+}
+
+
+def _python_blocks() -> list[tuple[str, int, str]]:
+    blocks = []
+    for md in sorted(DOCS_ROOT.rglob("*.md")):
+        text = md.read_text(encoding="utf-8")
+        rel = md.relative_to(DOCS_ROOT).as_posix()
+        for match in re.finditer(r"```python\n(.*?)```", text, re.S):
+            line = text[: match.start()].count("\n") + 1
+            blocks.append((rel, line, match.group(1)))
+    return blocks
+
+
+def _should_parse(code: str) -> bool:
+    if "..." in code or "…" in code:
+        return False
+    if _JS_BOUNDARY.search(code):
+        return False
+    stripped = code.strip()
+    return not (_SIGNATURE_LINE.match(stripped) and "\n" not in stripped)
+
+
+BLOCKS = _python_blocks()
+
+
+def test_the_docs_actually_contain_python_samples() -> None:
+    """Guard the guard: a broken glob would make every test below vacuous."""
+    assert len(BLOCKS) > 100, f"only found {len(BLOCKS)} python blocks — check DOCS_ROOT"
+
+
+@pytest.mark.parametrize(
+    ("rel", "line", "code"),
+    [pytest.param(r, ln, c, id=f"{r}:{ln}") for r, ln, c in BLOCKS],
+)
+def test_published_python_sample_parses(rel: str, line: int, code: str) -> None:
+    if rel in _ALLOWED_TRUNCATED:
+        pytest.skip(f"deliberate excerpt — {_ALLOWED_TRUNCATED[rel]}")
+    if not _should_parse(code):
+        pytest.skip("whole .pyxl file, abridged block, or signature display")
+    try:
+        ast.parse(code)
+    except SyntaxError as exc:
+        pytest.fail(
+            f"docs/{rel} line {line}: published Python sample does not parse — "
+            f"{exc.msg} (sample line {exc.lineno})"
+        )


### PR DESCRIPTION
Eleven fixes found by running the framework the way a stranger would, rather than by reading it. Each was reproduced first, fixed, and re-verified by running the thing; the whole set was then built into a wheel, installed into a clean venv, and exercised from that install.

**What a new user stops hitting**

- An occupied port explained itself instead of dumping `[Errno 98]` and — because Vite had already started, or the project had already rebuilt — blaming the wrong component. Both `dev` and `serve` now check the port before anything expensive. `serve` fails in well under a second where it used to fail after a full build, having already printed a `Serving on …` line with a clickable URL for a server that never bound.
- A deliberate `LoaderError(status_code=404)` was headed **Server Render Failed** for the developer while the visitor was told the truth.
- A client-side navigation reported an author-raised `LoaderError` as `ServerError`, so the same 404 answered differently depending on whether the URL was pasted or the link clicked. This one contradicted the error-handling guide, which promises the message reaches the visitor verbatim in every environment.
- `cookieSameSite: "none"` on a plain-HTTP origin broke CSRF completely and silently — a `SameSite=None` cookie must also be `Secure`, and browsers drop it without. Measured in a real browser: the page rendered perfectly and the browser kept zero cookies.
- `/llms.txt` published `http://` links on an HTTPS site whenever the TLS-terminating proxy was not one uvicorn already trusted.
- The API-routes guide's own multi-method example refused `HEAD`, so a route copied from our documentation turned away `curl -I`, uptime monitors and link checkers.
- A freshly scaffolded project's root `vite.config.js` raised `ERR_MODULE_NOT_FOUND` — the tools it exists to satisfy found a config that crashes.

**Also**

- `import pyxle.ssr.view` and `import pyxle.ssr.template` failed from a cold interpreter through a real import cycle. Invisible day to day, because `import pyxle` and the CLI enter from the other side; what it broke was a contributor reading one module.
- API modules were imported with `debug=True` hardcoded in production.
- `_discover_wrappers`' docstring was wrong about the order, the mechanism and the scope.
- Published sample output for `pyxle routes` did not match what the command prints.

**Guards, because several of these existed only because nothing was checking**

The `routes` test asserted only that the command had said *route(s) found*, so every drift in its output was silent. Nothing imports the docs, so a broken Python sample would have shipped and failed in a stranger's terminal — all 244 are now parsed by the suite. Two worker-pool tests asserted only that a call did not raise; one now asserts the behaviour, and the other says in-line that it is a guard rather than a proof, because it cannot be made to bite.

**Verification**

3,659 passed, 81 skipped, 96.80% coverage, ruff clean. Every fix was also exercised from the built wheel rather than the source tree, and hydration was confirmed in a real browser — React attached, and a real click moved the starter page's counter.