### PR TITLE
Keep the dev error overlay off deliberate 404s and off unrelated pages

### DIFF
--- a/pyxle/devserver/client_files.py
+++ b/pyxle/devserver/client_files.py
@@ -2543,7 +2543,7 @@ def _render_client_entry(settings: DevServerSettings) -> str:
                             border: '1px solid rgba(148, 163, 184, 0.6)',
                             cursor: 'pointer',
                           },
-                          onClick: clearOverlay,
+                          onClick: () => dismissOverlayError(event.routePath),
                         },
                         'Dismiss',
                       ),
@@ -2654,6 +2654,37 @@ def _render_client_entry(settings: DevServerSettings) -> str:
           );
         }
 
+        // Unresolved errors, keyed by route pattern, insertion-ordered so the
+        // newest is last. At most one overlay is ever shown: the newest error
+        // that applies to the page the developer is actually looking at.
+        const activeOverlayErrors = new Map();
+
+        function overlayAppliesHere(event) {
+          // A payload with no requestPath is not tied to one URL — a failed
+          // rebuild breaks every page — so it shows everywhere, as before.
+          if (!event || !event.requestPath) {
+            return true;
+          }
+          return event.requestPath === window.location.pathname;
+        }
+
+        // Render the applicable error, or nothing. Called whenever either half
+        // of the decision changes: a new socket message, or a client-side
+        // navigation that moved the developer to a different page.
+        function syncOverlay() {
+          let applicable = null;
+          activeOverlayErrors.forEach((event) => {
+            if (overlayAppliesHere(event)) {
+              applicable = event;
+            }
+          });
+          if (applicable) {
+            renderOverlay(applicable);
+          } else {
+            clearOverlay();
+          }
+        }
+
         function renderOverlay(event) {
           const root = ensureOverlayRoot();
           const stackLines = (event.stack ?? '').split('\\n').filter(Boolean);
@@ -2671,6 +2702,11 @@ def _render_client_entry(settings: DevServerSettings) -> str:
           container.__pyxle_overlay_root.render(null);
         }
 
+        function dismissOverlayError(routePath) {
+          activeOverlayErrors.delete(routePath);
+          syncOverlay();
+        }
+
         function connectOverlayChannel() {
           const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
           const url = `${protocol}//${window.location.host}/__pyxle__/overlay`;
@@ -2680,9 +2716,14 @@ def _render_client_entry(settings: DevServerSettings) -> str:
             try {
               const payload = JSON.parse(event.data);
               if (payload.type === 'error') {
-                renderOverlay(payload.payload ?? {});
+                const data = payload.payload ?? {};
+                // Re-insert so the newest failure sorts last.
+                activeOverlayErrors.delete(data.routePath);
+                activeOverlayErrors.set(data.routePath, data);
+                syncOverlay();
               } else if (payload.type === 'clear') {
-                clearOverlay();
+                activeOverlayErrors.delete((payload.payload ?? {}).routePath);
+                syncOverlay();
               } else if (payload.type === 'reload') {
                 const changed = Array.isArray(payload.payload?.changedPaths)
                   ? payload.payload.changedPaths
@@ -2717,7 +2758,10 @@ def _render_client_entry(settings: DevServerSettings) -> str:
         }
         """
     ).strip()
-    overlay_bootstrap_call = "connectOverlayChannel();\n"
+    overlay_bootstrap_call = (
+        "connectOverlayChannel();\n"
+        "window.addEventListener('pyxle:routechange', syncOverlay);\n"
+    )
 
     if settings.debug:
         overlay_injection = overlay_block + "\n\n" if overlay_block else ""

--- a/pyxle/devserver/overlay.py
+++ b/pyxle/devserver/overlay.py
@@ -132,18 +132,22 @@ class OverlayManager:
         await websocket.accept()
         async with self._lock:
             self._connections.add(websocket)
-            replay = next(reversed(self._active_errors.values()), None)
-        if replay is not None:
-            # Most recent first: the client renders one overlay, and the error
-            # the developer just caused is the one they are looking for.
+            replay = list(self._active_errors.values())
+        # Every unresolved error, oldest first. The client keeps only the ones
+        # that apply to the page it is actually on, so it has to be told about
+        # all of them: sending just the newest would hide a broken route
+        # whenever some *other* route broke more recently. Oldest first means
+        # the most recent applicable error is the one left showing.
+        for entry in replay:
             try:
                 await websocket.send_text(
-                    json.dumps({"type": "error", "payload": replay})
+                    json.dumps({"type": "error", "payload": entry})
                 )
             except Exception:
                 # The client went away between accept and the first send; drop
                 # it here rather than leaving a dead socket in the broadcast set.
                 await self.unregister(websocket)
+                break
 
     async def unregister(self, websocket: WebSocket) -> None:
         async with self._lock:
@@ -173,6 +177,7 @@ class OverlayManager:
         error: BaseException,
         stack: Optional[str] = None,
         breadcrumbs: Optional[List[Dict[str, str]]] = None,
+        request_path: Optional[str] = None,
     ) -> None:
         """Show an error for *route_path*, now and to clients that connect later.
 
@@ -180,9 +185,17 @@ class OverlayManager:
         called for the same route, which is what makes it survive a page
         reload: the reload drops the socket that was told about it, and the new
         socket is told on connect.
+
+        *request_path* is the concrete URL whose render failed (``/posts/3``,
+        where ``route_path`` is the pattern ``/posts/[id]``). The client renders
+        the overlay only while it is on that URL, so one broken route cannot
+        cover an unrelated working page. Omit it — as the rebuild pseudo-route
+        does — for a failure that really does affect every page; those still
+        show everywhere.
         """
         payload = {
             "routePath": route_path,
+            "requestPath": request_path,
             "message": str(error),
             "stack": stack or _format_stacktrace(error),
             "breadcrumbs": breadcrumbs or [],

--- a/pyxle/ssr/view.py
+++ b/pyxle/ssr/view.py
@@ -587,6 +587,7 @@ async def _handle_render_exception(
                 route_path=page.path,
                 error=exc,
                 breadcrumbs=_compose_breadcrumbs(loader_breadcrumb, stage="server", message=str(exc)),
+                request_path=request.url.path,
             )
         return _error_response(
             settings=settings,
@@ -598,11 +599,24 @@ async def _handle_render_exception(
         )
 
     if overlay is not None:
-        await overlay.notify_error(
-            route_path=page.path,
-            error=exc,
-            breadcrumbs=_compose_breadcrumbs(loader_breadcrumb, stage=stage, message=str(exc)),
-        )
+        if status_code < 500:
+            # An author-raised sub-500 — a loader choosing to answer 404 — is a
+            # response the developer wrote on purpose, not a crash. The dev
+            # overlay is a crash reporter, so it stays out of the way and lets
+            # the error boundary render, which is the whole point of raising it.
+            # `_log_render_failure` already draws this exact line; the overlay
+            # is the surface that never got the same rule. Clearing rather than
+            # doing nothing matters: a route that used to raise a real 500 and
+            # now answers a deliberate 404 has been fixed, and its old error
+            # must stop replaying.
+            await overlay.notify_clear(route_path=page.path)
+        else:
+            await overlay.notify_error(
+                route_path=page.path,
+                error=exc,
+                breadcrumbs=_compose_breadcrumbs(loader_breadcrumb, stage=stage, message=str(exc)),
+                request_path=request.url.path,
+            )
     # Log *before* the boundary attempt. A production response is deliberately
     # sanitized, so this log is the only record of what actually failed — and a
     # successfully rendered error.pyxl must not make the failure disappear from
@@ -1654,7 +1668,17 @@ async def _navigation_error_response(
 ) -> JSONResponse:
     breadcrumbs = _compose_breadcrumbs(loader_breadcrumb, stage=stage, message=str(error))
     if overlay is not None:
-        await overlay.notify_error(route_path=page.path, error=error, breadcrumbs=breadcrumbs)
+        if status_code < 500:
+            # Same rule as the document path: an author-chosen sub-500 is not a
+            # crash, so it does not raise the overlay.
+            await overlay.notify_clear(route_path=page.path)
+        else:
+            await overlay.notify_error(
+                route_path=page.path,
+                error=error,
+                breadcrumbs=breadcrumbs,
+                request_path=request.url.path,
+            )
 
     _log_render_failure(page, stage=stage, error=error, status_code=status_code)
 

--- a/tests/devserver/test_overlay.py
+++ b/tests/devserver/test_overlay.py
@@ -393,7 +393,14 @@ class TestErrorSurvivesReload:
         assert json.loads(socket.sent[0])["payload"]["routePath"] == "(rebuild)"
 
     @pytest.mark.anyio
-    async def test_the_most_recent_error_is_the_one_replayed(self) -> None:
+    async def test_every_unresolved_error_is_replayed_newest_last(self) -> None:
+        """A reconnecting client is told about all of them, not just the newest.
+
+        The client keeps only the errors that apply to the page it is on, so it
+        has to hear about every one: replaying only the most recent would hide a
+        broken route whenever some *other* route broke after it. Newest last,
+        because the client shows the last applicable error it was told about.
+        """
         manager = OverlayManager(logger=StubLogger())
         await manager.notify_error(route_path="/first", error=RuntimeError("older"))
         await manager.notify_error(route_path="/second", error=RuntimeError("newer"))
@@ -401,7 +408,41 @@ class TestErrorSurvivesReload:
         socket = StubWebSocket()
         await manager.register(socket)
 
-        assert json.loads(socket.sent[0])["payload"]["routePath"] == "/second"
+        replayed = [json.loads(m)["payload"]["routePath"] for m in socket.sent]
+        assert replayed == ["/first", "/second"]
+
+    @pytest.mark.anyio
+    async def test_notify_error_carries_the_url_that_failed(self) -> None:
+        """The concrete URL, so the client can tell whose page is broken.
+
+        ``routePath`` is the pattern (``/posts/[id]``); ``requestPath`` is the
+        URL the developer actually asked for. Without it the client cannot tell
+        an error on the page it is showing from an error on some other page.
+        """
+        manager = OverlayManager(logger=StubLogger())
+        socket = StubWebSocket()
+        await manager.register(socket)
+
+        await manager.notify_error(
+            route_path="/posts/[id]",
+            error=RuntimeError("boom"),
+            request_path="/posts/3",
+        )
+
+        payload = json.loads(socket.sent[0])["payload"]
+        assert payload["routePath"] == "/posts/[id]"
+        assert payload["requestPath"] == "/posts/3"
+
+    @pytest.mark.anyio
+    async def test_an_error_with_no_url_still_applies_everywhere(self) -> None:
+        """A failed rebuild breaks every page, so it is not scoped to one URL."""
+        manager = OverlayManager(logger=StubLogger())
+        socket = StubWebSocket()
+        await manager.register(socket)
+
+        await manager.notify_error(route_path="(rebuild)", error=RuntimeError("boom"))
+
+        assert json.loads(socket.sent[0])["payload"]["requestPath"] is None
 
     @pytest.mark.anyio
     async def test_repeating_an_error_keeps_one_entry_per_route(self) -> None:

--- a/tests/ssr/test_view.py
+++ b/tests/ssr/test_view.py
@@ -94,6 +94,7 @@ class StubRenderer:
 class StubOverlay:
     def __init__(self) -> None:
         self.events: list[tuple[str, str] | tuple[str, str, list[dict[str, str]]]] = []
+        self.request_paths: list[str | None] = []
 
     async def notify_clear(self, route_path: str) -> None:
         self.events.append(("clear", route_path))
@@ -104,8 +105,10 @@ class StubOverlay:
         error: BaseException,
         *,
         breadcrumbs: list[dict[str, str]] | None = None,
+        request_path: str | None = None,
     ) -> None:
         self.events.append(("error", route_path, breadcrumbs or []))
+        self.request_paths.append(request_path)
 
 
 async def _read_response_body(response) -> bytes:
@@ -1493,8 +1496,12 @@ async def test_build_page_response_loader_error_hits_error_boundary(
     assert response.status_code == 403
     body = (await _read_response_body(response)).decode()
     assert "Not allowed" in body
-    # Overlay should have received an error event
-    assert any(ev[0] == "error" for ev in overlay.events)
+    # A 403 the author raised on purpose is a response, not a crash, so the dev
+    # overlay stays down and the boundary above is what the developer sees. The
+    # route is cleared rather than left alone, so an earlier real fault on the
+    # same route stops replaying once the author starts answering deliberately.
+    assert not any(ev[0] == "error" for ev in overlay.events)
+    assert ("clear", "/") in overlay.events
 
 
 @pytest.mark.anyio
@@ -1598,6 +1605,85 @@ async def _nav_payload(page: PageRoute, settings: DevServerSettings) -> dict:
         overlay=StubOverlay(),
     )
     return json.loads(await _read_response_body(response)), response.status_code
+
+
+@pytest.mark.anyio
+async def test_a_deliberate_404_does_not_raise_the_dev_overlay(
+    settings: DevServerSettings, tmp_path: Path
+) -> None:
+    """A loader answering 404 on purpose must not be reported as a crash.
+
+    The dev overlay is a crash reporter. A ``LoaderError(..., status_code=404)``
+    is a response the author wrote — the error boundary renders it, which is the
+    entire point of raising it — so covering the screen with
+    *"Loader FAILED / Renderer BLOCKED"* and a traceback describes the developer's
+    own deliberate code as a failure. ``_log_render_failure`` already draws this
+    line for the server log; this is the same rule on the surface that missed it.
+    """
+    page = _nav_page_raising(
+        tmp_path,
+        "raise LoaderError('That post was deleted in 2019.', status_code=404)",
+        "overlay_deliberate_404",
+    )
+    overlay = StubOverlay()
+
+    await build_page_navigation_response(
+        request=Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/nav",
+                "query_string": b"",
+                "headers": [],
+            }
+        ),
+        settings=settings,
+        page=page,
+        renderer=StubRenderer(),
+        overlay=overlay,
+    )
+
+    assert not any(ev[0] == "error" for ev in overlay.events)
+    assert ("clear", "/nav") in overlay.events
+
+
+@pytest.mark.anyio
+async def test_a_genuine_fault_still_raises_the_dev_overlay_and_names_its_url(
+    settings: DevServerSettings, tmp_path: Path
+) -> None:
+    """The overlay must keep doing its job for real crashes.
+
+    Two things at once: a 500 still reports, and it carries the URL that broke.
+    The client shows the overlay only while it is on that URL, so without
+    ``request_path`` one broken route covers every other page — a working page
+    is then not merely obscured but unusable, because the full-screen overlay
+    swallows its clicks.
+    """
+    page = _nav_page_raising(
+        tmp_path,
+        "raise RuntimeError('genuine server fault')",
+        "overlay_real_fault",
+    )
+    overlay = StubOverlay()
+
+    await build_page_navigation_response(
+        request=Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/nav",
+                "query_string": b"",
+                "headers": [],
+            }
+        ),
+        settings=settings,
+        page=page,
+        renderer=StubRenderer(),
+        overlay=overlay,
+    )
+
+    assert any(ev[0] == "error" for ev in overlay.events)
+    assert overlay.request_paths == ["/nav"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
A loader raising `LoaderError("...", status_code=404)` is a response the author chose, not a crash — but the development error overlay covered the screen with **"Loader FAILED / Renderer BLOCKED"** and a Python traceback for it. The framework already treats an intentional sub-500 as "not a server error" when deciding what to log; the overlay was the surface that had never been given the same rule.

The overlay also replayed one route's error to *every* page. Because it renders full-screen at the top layer, an unrelated working page was not merely obscured, it was unusable — it swallowed the clicks. In a scaffolded project, with one route deliberately answering 404, the home page's counter button stayed at "Clicked 0 times" no matter how often it was clicked.

**What changes**

- An author-raised error with a status below 500 no longer raises the overlay. The route is cleared instead, so a route that used to fail for real and now answers a deliberate 404 stops replaying its old error.
- An error is scoped to the URL that failed, so it can only cover that page. A failure that is not tied to one URL — a failed rebuild, which really does break every page — still shows everywhere.
- Reconnecting clients are told about every unresolved error rather than only the newest, which previously hid a broken route whenever another route broke after it.
- The overlay re-evaluates on client-side navigation, so navigating away from a broken page clears it.

**Verification**

Checked in a browser across six cases: a genuine 500 still raises the overlay; an unrelated page stays clean and clickable; a deliberate 404 renders the error boundary with no overlay; the error still survives a reload; navigating to the broken page raises it; navigating away clears it.

Suite: 3,663 passed, 96.80% coverage, ruff clean.