### PR TITLE
Load the root vite.config.js after a build, not just before one

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,28 @@
 
 Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include breaking changes — those are called out explicitly. To upgrade, run `pip install --upgrade pyxle-framework`.
 
+## Unreleased
+
+- **Fix: the root `vite.config.js` now loads *after* a build too.** 0.9.2 stopped
+  a freshly scaffolded project's root config from throwing
+  `ERR_MODULE_NOT_FOUND` before the first build, and it did — but it left a
+  second failure in its place. The generated config it defers to sets
+  `const clientRoot = __dirname`, and a scaffolded project's `package.json`
+  declares `"type": "module"`, so that identifier does not exist there. Nothing
+  caught it because Vite injects `__dirname` when it *bundles* the config it is
+  handed directly, which is exactly how `pyxle dev` and `pyxle build` load it;
+  the root config instead reaches the generated one through a runtime dynamic
+  `import()`, which no bundler rewrites. So from 0.9.2 any tool that reads the
+  project's Vite config got `__dirname is not defined in ES module scope` on a
+  project that had been built. **Vitest could not start at all** — the failure
+  surfaces as a stack trace pointing inside `.pyxle-build/`, a directory you did
+  not write. Measured with Vite's own `loadConfigFromFile`: 0.9.1 failed before a
+  build and worked after; 0.9.2 was the exact inverse. Both states now work, and
+  `vitest run` goes from unable to start to passing. (`shadcn` is unaffected by *this*
+  bug — it does not read the Vite config at all.) `clientRoot` is derived
+  from `import.meta.url`, and a test asserts the generated config contains no
+  `__dirname` in code.
+
 ## 0.9.2
 
 - **Internal: API modules are imported with the real `debug` flag, not a

--- a/pyxle/devserver/client_files.py
+++ b/pyxle/devserver/client_files.py
@@ -690,9 +690,18 @@ def _render_vite_config(settings: DevServerSettings) -> str:
             import react from '@vitejs/plugin-react';{tailwind_import}
             import fs from 'node:fs';
             import path from 'node:path';
-            import {{ pathToFileURL }} from 'node:url';
+            import {{ fileURLToPath, pathToFileURL }} from 'node:url';
 
-            const clientRoot = __dirname;
+            // ESM, not CommonJS: the project's package.json says
+            // "type": "module", so `__dirname` is not defined here. Vite
+            // happens to inject it when it bundles this file as the config it
+            // was handed directly — which is how `pyxle dev` and `pyxle build`
+            // load it, and why the gap stayed invisible. The root
+            // `vite.config.js` reaches this file through a runtime dynamic
+            // `import()` instead, which no bundler rewrites, so `__dirname`
+            // was genuinely undefined for every ecosystem tool that loads the
+            // project's config — the exact audience that file exists for.
+            const clientRoot = path.dirname(fileURLToPath(import.meta.url));
             const projectRoot = path.resolve(clientRoot, '..', '..');
             const pyxleClientDir = path.resolve(clientRoot, 'pyxle');
             const base = process.env.PYXLE_VITE_BASE ?? '/';

--- a/tests/devserver/test_client_files.py
+++ b/tests/devserver/test_client_files.py
@@ -565,6 +565,34 @@ def test_vite_config_aliases_cover_client_runtime(tmp_path: Path) -> None:
     assert "find: 'pyxle/client'" not in vite_config
 
 
+def test_vite_config_is_valid_esm_and_never_uses_dirname(tmp_path: Path) -> None:
+    """The generated config must not rely on `__dirname`.
+
+    A scaffolded project's package.json declares ``"type": "module"``, so this
+    ``.js`` file is ESM and ``__dirname`` does not exist in it. Vite injects one
+    when it *bundles* the file as the config it was handed directly — which is
+    how ``pyxle dev`` and ``pyxle build`` load it, and why this stayed invisible
+    for so long. The project's root ``vite.config.js`` reaches it through a
+    runtime dynamic ``import()``, which nothing rewrites, so every ecosystem
+    tool that loads the project config (``shadcn`` framework detection, editor
+    integrations — the audience that file exists to serve) got
+    ``__dirname is not defined in ES module scope``.
+
+    Assert on code, not on the whole text, so the explanatory comment naming
+    ``__dirname`` cannot make this test vacuous.
+    """
+    vite_config = _render_vite_config(tmp_path and create_project(tmp_path))
+
+    code = "\n".join(
+        line
+        for line in vite_config.splitlines()
+        if not line.lstrip().startswith("//")
+    )
+    assert "__dirname" not in code
+    assert "fileURLToPath" in code
+    assert "const clientRoot = path.dirname(fileURLToPath(import.meta.url));" in code
+
+
 def _write_package_json(root: Path, *, tailwind: bool) -> None:
     dev = {"vite": "^7"}
     if tailwind:
@@ -1357,7 +1385,10 @@ def test_vite_config_embeds_pyxl_sourcemap_plugin(tmp_path: Path) -> None:
     assert "if (!mappedLines.has(i + 1)) srcLines[i] = '';" in config
     # The plugin's runtime imports are part of the config prelude.
     assert "import fs from 'node:fs';" in config
-    assert "import { pathToFileURL } from 'node:url';" in config
+    # `fileURLToPath` joined this import when the config stopped using
+    # `__dirname` (see test_vite_config_is_valid_esm_and_never_uses_dirname).
+    # What matters here is that the sourcemap plugin's dependency is imported.
+    assert "import { fileURLToPath, pathToFileURL } from 'node:url';" in config
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Version 0.9.2 stopped a freshly scaffolded project's root `vite.config.js` from throwing `ERR_MODULE_NOT_FOUND` before the first build. It did — but it left a second failure in its place.

The generated config it defers to sets `const clientRoot = __dirname`, and a scaffolded project's `package.json` declares `"type": "module"`, so that identifier does not exist there. Nothing caught it because Vite injects `__dirname` when it *bundles* the config it is handed directly, which is how `pyxle dev` and `pyxle build` load it. The root config instead reaches the generated one through a runtime dynamic `import()`, which no bundler rewrites.

So from 0.9.2, any tool that reads the project's Vite config hit it on a project that had been built. **Vitest could not start at all**, failing with a stack trace pointing inside `.pyxle-build/` — a directory the developer did not write.

Measured with Vite's own `loadConfigFromFile`:

| | before a build | after a build |
|---|---|---|
| 0.9.1 | fails `ERR_MODULE_NOT_FOUND` | loads |
| 0.9.2 | loads | fails `__dirname is not defined` |

Both states now work. `clientRoot` is derived from `import.meta.url`, and `vitest run` goes from unable to start to passing.

A test asserts the generated config contains no `__dirname` in code — keyed on code rather than the whole file, so the comment explaining the history cannot make it vacuous.

Note: `shadcn` is unaffected by this particular bug; it does not read the Vite config at all.