### PR TITLE
Scan the project's own source directories for Tailwind classes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,25 @@
 
 Release notes for Pyxle. While we're in beta (`0.x`), minor versions may include breaking changes — those are called out explicitly. To upgrade, run `pip install --upgrade pyxle-framework`.
 
+## Unreleased
+
+- **Fix: `shadcn/ui` components are styled. Tailwind now scans your own source
+  directories.** Vite's root is the generated client directory, which holds the
+  *compiled* pages and nothing else, and Tailwind v4 auto-detects its sources
+  from that root. So a utility class used only in your own `components/` — which
+  is exactly where `shadcn/ui` puts every component it installs — was never
+  generated, and the component rendered **unstyled, with no error anywhere**:
+  `npx shadcn@latest add button` reported success and the button came out with
+  no background. Adding `@source "../../components"` to your stylesheet did not
+  help either, because the stylesheet is copied into the build directory, so
+  that path resolved inside it and silently matched nothing. Pyxle now rewrites
+  the directives at copy time, pointing Tailwind at the directories your
+  `jsconfig.json` declares (`pages` excluded — it is already under the Vite
+  root). Verified in a browser on a scaffolded shadcn project: a class present
+  only in `components/ui/button.jsx` now generates, in `pyxle dev` and in the
+  production bundle. Plain-CSS projects are untouched — nothing is injected into
+  a stylesheet that does not import Tailwind.
+
 ## 0.9.2
 
 - **Internal: API modules are imported with the real `debug` flag, not a

--- a/pyxle/devserver/builder.py
+++ b/pyxle/devserver/builder.py
@@ -26,7 +26,7 @@ from .layouts import compose_layout_templates
 from .scanner import SourceFile, SourceKind, scan_source_tree
 from .scripts import sync_global_scripts
 from .settings import DevServerSettings
-from .styles import sync_global_stylesheets
+from .styles import inject_tailwind_sources, sync_global_stylesheets
 
 
 @dataclass(slots=True)
@@ -165,7 +165,21 @@ def _build_once_locked(settings: DevServerSettings, *, force_rebuild: bool) -> B
             destination = paths.client_root / "pages" / source.relative_path
             if changed:
                 destination.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(source.absolute_path, destination)
+                if destination.suffix == ".css":
+                    # Rewritten rather than copied: a Tailwind stylesheet needs
+                    # `@source` paths that point back at the project's own
+                    # directories, which only makes sense once we know where the
+                    # copy landed. See styles.inject_tailwind_sources.
+                    destination.write_text(
+                        inject_tailwind_sources(
+                            source.absolute_path.read_text(encoding="utf-8"),
+                            destination=destination,
+                            project_root=settings.project_root,
+                        ),
+                        encoding="utf-8",
+                    )
+                else:
+                    shutil.copy2(source.absolute_path, destination)
                 summary.copied_client_assets.append(relative_key)
             else:
                 summary.skipped.append(relative_key)

--- a/pyxle/devserver/styles.py
+++ b/pyxle/devserver/styles.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
@@ -89,6 +92,78 @@ def resolve_global_stylesheets(
         )
 
     return tuple(resolved)
+
+
+
+#: Where a project's own source lives when ``jsconfig.json`` does not say.
+#: ``pages`` is deliberately absent: it is compiled into the Vite root, so
+#: Tailwind already finds it.
+_DEFAULT_SOURCE_DIRS: tuple[str, ...] = ("components", "lib")
+
+_TAILWIND_IMPORT = re.compile(r"""^[ \t]*@import[ \t]+["']tailwindcss["'][^\n]*$""", re.M)
+
+#: Marks our injected block so a second copy does not stack another one.
+_SOURCE_MARKER = "/* pyxle: Tailwind source roots (generated) */"
+
+
+def _jsconfig_include(project_root: Path) -> list[str]:
+    """Directory names listed in ``jsconfig.json``'s ``include``."""
+    try:
+        data = json.loads((project_root / "jsconfig.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    include = data.get("include")
+    if not isinstance(include, list):
+        return []
+    return [entry for entry in include if isinstance(entry, str)]
+
+
+def project_source_dirs(project_root: Path) -> list[Path]:
+    """Existing directories holding the project's own source files.
+
+    Taken from ``jsconfig.json``'s ``include`` — the same declaration the editor
+    and shadcn/ui read — falling back to a conventional default. ``pages`` is
+    dropped: its compiled output already sits under the Vite root.
+    """
+    names = _jsconfig_include(project_root) or list(_DEFAULT_SOURCE_DIRS)
+    dirs: list[Path] = []
+    for name in names:
+        if name == "pages":
+            continue
+        candidate = project_root / name
+        if candidate.is_dir() and candidate not in dirs:
+            dirs.append(candidate)
+    return dirs
+
+
+def inject_tailwind_sources(css: str, *, destination: Path, project_root: Path) -> str:
+    """Point Tailwind at the project's own source directories.
+
+    Vite's root is the generated client directory, which holds the *compiled*
+    pages and nothing else. Tailwind v4 auto-detects its sources from that root,
+    so a utility class used only in the project's own ``components/`` — which is
+    exactly where ``shadcn/ui`` puts every component it installs — is never
+    generated, and the component renders unstyled with no error anywhere.
+
+    The stylesheet is copied into the build directory, so a hand-written
+    ``@source "../../components"`` in the project's CSS resolves *inside* that
+    directory and silently matches nothing. The paths therefore have to be
+    rewritten at copy time, which is what this does. Returns *css* unchanged
+    when it does not import Tailwind.
+    """
+    if _SOURCE_MARKER in css:
+        return css
+    match = _TAILWIND_IMPORT.search(css)
+    if match is None:
+        return css
+    dirs = project_source_dirs(project_root)
+    if not dirs:
+        return css
+    block = [_SOURCE_MARKER]
+    for directory in dirs:
+        relative = os.path.relpath(directory, destination.parent).replace(os.sep, "/")
+        block.append(f'@source "{relative}";')
+    return css[: match.end()] + "\n" + "\n".join(block) + css[match.end() :]
 
 
 def sync_global_stylesheets(
@@ -178,5 +253,7 @@ __all__ = [
     "GlobalStylesheet",
     "resolve_global_stylesheets",
     "sync_global_stylesheets",
+    "inject_tailwind_sources",
+    "project_source_dirs",
     "load_inline_stylesheets",
 ]

--- a/tests/devserver/test_styles.py
+++ b/tests/devserver/test_styles.py
@@ -9,6 +9,8 @@ from pyxle.devserver.styles import (
     GlobalStylesheet,
     _make_identifier,
     _normalize_relative_path,
+    inject_tailwind_sources,
+    project_source_dirs,
     load_inline_stylesheets,
     resolve_global_stylesheets,
     sync_global_stylesheets,
@@ -149,3 +151,98 @@ def test_load_inline_stylesheets_skips_missing_files(tmp_path: Path) -> None:
     payloads = load_inline_stylesheets([existing, missing])
 
     assert payloads == [(existing, "body {}")]
+
+
+# ---------------------------------------------------------------------------
+# Tailwind source roots
+# ---------------------------------------------------------------------------
+
+
+def _tailwind_project(tmp_path: Path) -> tuple[Path, Path]:
+    """A project whose stylesheet is copied into the generated client dir."""
+    (tmp_path / "components" / "ui").mkdir(parents=True)
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "pages" / "styles").mkdir(parents=True)
+    destination = tmp_path / ".pyxle-build" / "client" / "pages" / "styles" / "app.css"
+    destination.parent.mkdir(parents=True)
+    return tmp_path, destination
+
+
+def test_tailwind_sources_point_back_at_the_project(tmp_path: Path) -> None:
+    """Without this, every shadcn/ui component renders unstyled.
+
+    Vite's root is the generated client directory, which holds the compiled
+    pages and nothing else, and Tailwind v4 auto-detects its sources from that
+    root. A class used only in the project's own ``components/`` — where shadcn
+    puts everything it installs — is therefore never generated, and the
+    component renders with no styling and no error anywhere.
+
+    The paths must be relative to where the copy *landed*, not to the file the
+    developer wrote: a hand-written ``@source "../../components"`` resolves
+    inside ``.pyxle-build/`` and silently matches nothing.
+    """
+    project_root, destination = _tailwind_project(tmp_path)
+
+    result = inject_tailwind_sources(
+        '@import "tailwindcss";\nbody { margin: 0; }\n',
+        destination=destination,
+        project_root=project_root,
+    )
+
+    assert '@source "../../../../components";' in result
+    assert '@source "../../../../lib";' in result
+    # the original content survives, and the import still comes first
+    assert result.index("@import") < result.index("@source")
+    assert "body { margin: 0; }" in result
+
+
+def test_a_stylesheet_without_tailwind_is_untouched(tmp_path: Path) -> None:
+    """Plain CSS projects get no injected directives."""
+    project_root, destination = _tailwind_project(tmp_path)
+    css = "body { margin: 0; }\n"
+
+    assert (
+        inject_tailwind_sources(css, destination=destination, project_root=project_root)
+        == css
+    )
+
+
+def test_injecting_twice_does_not_stack_directives(tmp_path: Path) -> None:
+    """Rebuilds re-copy the stylesheet; the block must not accumulate."""
+    project_root, destination = _tailwind_project(tmp_path)
+    once = inject_tailwind_sources(
+        '@import "tailwindcss";\n', destination=destination, project_root=project_root
+    )
+    twice = inject_tailwind_sources(
+        once, destination=destination, project_root=project_root
+    )
+
+    assert once == twice
+    assert twice.count("@source") == 2
+
+
+def test_source_dirs_follow_jsconfig_and_skip_pages(tmp_path: Path) -> None:
+    """``jsconfig.json`` is the project's own declaration of where source lives.
+
+    ``pages`` is excluded deliberately — it is compiled into the Vite root, so
+    Tailwind already sees it — and a listed directory that does not exist is
+    skipped rather than emitted as a dead path.
+    """
+    (tmp_path / "components").mkdir()
+    (tmp_path / "widgets").mkdir()
+    (tmp_path / "pages").mkdir()
+    (tmp_path / "jsconfig.json").write_text(
+        '{"include": ["pages", "components", "widgets", "absent"]}', encoding="utf-8"
+    )
+
+    names = [directory.name for directory in project_source_dirs(tmp_path)]
+
+    assert names == ["components", "widgets"]
+    assert "pages" not in names
+    assert "absent" not in names
+
+
+def test_source_dirs_fall_back_when_jsconfig_is_missing(tmp_path: Path) -> None:
+    (tmp_path / "components").mkdir()
+
+    assert [d.name for d in project_source_dirs(tmp_path)] == ["components"]


### PR DESCRIPTION
Vite's root is the generated client directory, which holds the *compiled* pages and nothing else, and Tailwind v4 auto-detects its sources from that root. A utility class used only in the project's own `components/` — exactly where `shadcn/ui` puts every component it installs — was therefore never generated, and the component rendered **unstyled, with no error anywhere**.

`npx shadcn@latest add button` reported success and the button came out with no background. The quick-start guide says shadcn/ui is set up "so `npx shadcn@latest add button` just works"; it did not.

Adding `@source "../../components"` to the project's stylesheet did not help either. The stylesheet is copied into the build directory, so that path resolved inside it and silently matched nothing — only a path like `../../../../components`, which encodes the build layout into the developer's own CSS, would have worked.

**What changes**

The directives are rewritten at copy time, relative to where the copy landed, pointing at the directories `jsconfig.json` declares — the same file the editor and shadcn read. `pages` is excluded, since it is compiled into the Vite root already. A stylesheet that does not import Tailwind is left untouched, so plain-CSS projects and Tailwind v3 projects are unaffected.

**Verification**

Checked in a browser on a scaffolded shadcn project: a class present only in `components/ui/button.jsx` now generates, both under `pyxle dev` and in the production bundle. Before the change the same button computed to a transparent background; after it, the theme's primary colour.

Suite: 3,664 passed, 96.79% coverage, ruff clean. Also run on Python 3.10 in a clean environment: 3,668 passed together with the other fixes in flight.