### PR TITLE
Document how the dev error overlay is scoped and replayed

### DIFF
--- a/docs/architecture/dev-server.md
+++ b/docs/architecture/dev-server.md
@@ -627,9 +627,14 @@ connected client.
 Event types:
 
 - `"error"` — sent when a build fails or a runtime error occurs.
-  Includes the error message, stack, and "breadcrumbs" describing
-  which stage of the request pipeline failed (loader, render, head
-  evaluation, etc.).
+  Includes the error message, stack, "breadcrumbs" describing which
+  stage of the request pipeline failed (loader, render, head
+  evaluation, etc.), and the URL whose render failed. An error the
+  author *chose* — a loader raising `LoaderError` with a status below
+  500 — is not sent at all: it is a response, not a crash, and the
+  overlay is a crash reporter. The route is cleared instead, so a route
+  that used to fail for real and now answers a deliberate 404 stops
+  replaying its old error.
 - `"clear"` — sent when a previously-failing route succeeds. The
   client uses this to dismiss any visible error overlay.
 - `"reload"` — sent after a successful rebuild — including a rebuild
@@ -638,10 +643,22 @@ Event types:
 
 An error is not a one-off broadcast: the manager keeps the current
 error for each route (keyed by route path, plus `(rebuild)` for build
-failures) and replays the most recent one to every client that connects
-afterwards. A reload closes the socket that was told about the error and
-opens a new one, so without the replay a reload made the error vanish
-while the fault remained. `"clear"` for a route drops that route's entry
+failures) and replays **every** unresolved one, oldest first, to each
+client that connects afterwards. A reload closes the socket that was
+told about the error and opens a new one, so without the replay a reload
+made the error vanish while the fault remained. Replaying all of them
+rather than only the newest is what stops a broken route being hidden
+whenever some *other* route breaks after it.
+
+The client shows at most one overlay: the most recent error that applies
+to the page it is actually on. An error carries the concrete URL that
+failed, and is displayed only while the browser is at that URL — so a
+broken `/reports` cannot cover `/`, which matters because the overlay
+renders full-screen at the top layer and would otherwise swallow that
+page's clicks. A payload with no URL is not tied to one page — a failed
+rebuild really does break every page — and still shows everywhere. The
+client re-evaluates on client-side navigation, so navigating away from a
+broken page clears it. `"clear"` for a route drops that route's entry
 and only that one, so a healthy render of `/` never silences a build
 failure in `pages/about.pyxl`.
 The socket accepts the origins in

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -321,16 +321,30 @@ Like error boundaries, not-found pages follow directory scoping -- a `not-found.
 
 ## Dev mode error overlay
 
-During development (`pyxle dev`), errors also appear in a browser overlay with:
+During development (`pyxle dev`), a **fault** also appears in a browser overlay
+with:
 
 - The error message and stack trace
 - Breadcrumbs showing which stage failed (loader, renderer, hydration)
 - File path and line number
 
-The overlay communicates via WebSocket and updates in real time as you fix errors.
-It also **survives a reload**: the current error is replayed to the page when it
-reconnects, so an error raised while no tab was open — or one you reloaded past —
-still shows.
+An error you raised on purpose does **not** open it. A `LoaderError` with a
+status below 500 — a 404 for a post that does not exist, a 403 for a page the
+visitor may not see — is a response you wrote, so the overlay stays out of the
+way and your `error.pyxl` renders, which is the whole point of raising it. The
+same rule the server log already follows: an intentional sub-500 is not a server
+error.
+
+The overlay belongs to the page that failed. It is shown only while you are on
+the URL whose render failed, so a broken `/reports` never covers a working `/` —
+it renders full-screen, and an overlay on the wrong page would swallow that
+page's clicks. A failure that is not tied to one URL, such as a failed rebuild,
+does break every page and still shows on all of them.
+
+It communicates via WebSocket and updates in real time as you fix errors. It also
+**survives a reload**: unresolved errors are replayed when the page reconnects,
+so a fault raised while no tab was open — or one you reloaded past — still shows.
+Navigating away from the broken page clears it.
 
 ## A page that will not compile
 


### PR DESCRIPTION
Two pages still described the overlay as it behaved before it learned to stay off deliberate sub-500 responses and to stay on the page that failed.

- **`architecture/dev-server.md`** said the manager replays *"the most recent"* error to a client that connects. It replays **every** unresolved one, oldest first, so a broken route is not hidden whenever another route breaks after it. The page also described the `"error"` event as sent for any runtime error; an author-raised `LoaderError` with a status below 500 is no longer sent at all.
- **`guides/error-handling.md`** said errors appear in a browser overlay during development, with nothing about deliberate sub-500s being exempt and nothing about the overlay belonging to the page that failed — which is the part a developer actually notices, because it renders full-screen and used to cover unrelated working pages.

Both now describe the shipped behaviour, including that a failure which is not tied to one URL — a failed rebuild — still shows on every page.

Documentation only; no code changes.