### PR TITLE
Say to restart pyxle dev after installing a Node package

### DIFF
--- a/docs/guides/third-party-packages.md
+++ b/docs/guides/third-party-packages.md
@@ -4,6 +4,14 @@ A Pyxle project has **two** dependency sets: Python packages (used by your
 `@server` loaders, `@action` mutations, and `pages/api/*.py` endpoints) and Node
 packages (used by your React/JSX components). Add to whichever side you need.
 
+> **After installing a new Node package, restart `pyxle dev`.** Until you do,
+> the page can fail to hydrate, with a misleading React error in the console —
+> `Invalid hook call` or `more than one copy of React` — while the server-side
+> render still looks fine. Nothing is wrong with your React versions: Vite's
+> dependency cache predates the new package, and the restart rebuilds it. This
+> bites hardest right after following an example, because the install is the
+> step you just did.
+
 ## Python packages (pip)
 
 Add the package to `requirements.txt` and install:


### PR DESCRIPTION
Installing an npm package while `pyxle dev` runs deterministically breaks hydration on the next load — the console blames React versions ("Invalid hook call" / "more than one copy of React") when the actual fix is restarting the dev server so Vite rebuilds its dependency cache. Reproduced 2/2 by independent evaluations of 0.9.3 following this guide literally, including via the guide's own Recharts example.

One callout at the top of the guide, before either install section. Docs only.