### PR TITLE
Deployment docs describe the real multi-worker migration behaviour

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -557,8 +557,10 @@ pyxle serve --skip-build
 Guidelines:
 
 - **Run migrations once per deploy, before starting the new server** — not per
-  worker. Each migration is applied exactly once and atomically, so a race is
-  safe, but running it up front keeps the outcome visible in your deploy logs.
+  worker. Workers that do race a pending migration serialize on a database
+  lock — one applies it, the rest verify the recorded checksum and continue —
+  but running migrations up front keeps the outcome visible in your deploy
+  logs instead of spread across worker startups.
 - **Never edit an already-applied migration** — the checksum tracker rejects it.
   Add a new migration file instead.
 - **For zero-downtime (blue-green) deploys, keep migrations backward-compatible**

--- a/docs/plugins/pyxle-db.md
+++ b/docs/plugins/pyxle-db.md
@@ -219,6 +219,7 @@ migrations/
 Rules the migrator enforces:
 
 - **Applied exactly once, atomically.** Each migration's statements and its tracking-table insert commit together or not at all.
+- **Concurrency-safe across workers.** When several server workers start with the same pending migration, appliers serialize on a database lock (SQLite `BEGIN IMMEDIATE`, PostgreSQL `pg_advisory_xact_lock`, MySQL `GET_LOCK`): exactly one applies it, and the rest verify the recorded checksum matches their file and continue.
 - **Checksum-tracked.** Editing an already-applied migration is detected and rejected — write a new migration instead.
 - **Per-dialect overrides.** `<NNN>-<slug>.<dialect>.sql` replaces the base file on that backend (the example above uses MySQL-specific DDL while SQLite and PostgreSQL share the base file). An override with no base file is a backend-only migration.
 - **Namespaced tracking.** The default tracking table is `schema_migrations`; libraries that bring their own migrations onto your database (pyxle-auth does) use a private tracking table via `Migrator(db, dir, tracking_table=...)` so two migration histories never see each other as drift.


### PR DESCRIPTION
The deployment guide claimed concurrent migration application by multiple
workers was already safe. It was not — the loser of that race crashed at
startup — until pyxle-db serialized migration application (pyxle-dev/pyxle-plugins#10).
Both pages now describe the actual mechanics: per-backend serialization, the
losing worker verifying the recorded checksum and continuing, and a genuine
checksum mismatch still failing loudly.

## Checklist

- [x] `pytest` passes and coverage stays ≥ 95%
- [x] `ruff check pyxle/ tests/` is clean
- [x] New behavior has tests in the matching `tests/` directory — not applicable, documentation-only change
- [x] Touched the parser or SSR? Added regression tests and verified `pyxle init` + `pyxle dev` still work end-to-end — not touched
- [x] One focused change; commit messages follow Conventional Commits (`scope`: `compiler`, `ssr`, `cli`, …)
